### PR TITLE
Index phase 1: canonical SymbolId

### DIFF
--- a/ai/index-progress.md
+++ b/ai/index-progress.md
@@ -20,5 +20,11 @@
 
 - **3.3** IndexManager wired into server lifecycle (Smithy ops, initialized background indexing, didSave index update, stub handlers)
 
+## Architecture-improvements plan
+- **Phase 0** Test foundation — name-based → id-based assertions, orchestration tests, cross-producer fixture, round-trip determinism (PR #63)
+
+- **Phase 1** Canonical `SymbolId` — case-class with `pkg/owners/name/member`. Producers go through `fromTasty/fromJvm/fromSemanticDb/fromJava` factories; `Cls.foo` vs `Cls#foo` drift removed. `CrossProducerSpec` flipped from `ignore(...)` to green across all 6 cases (top-level class, companion object, overloaded method, inner class, Java class, Java overloaded method). `DepIndexCache.Version` bumped to 3.
+
 ## Next
+- **Phase 2** `SymbolIndexer` trait + strategy ADT — make `IndexManager.indexJarSafely` 5 lines of composition; land the deferred TASTy-crash → bytecode fallback test
 - **5.1–5.6** LSP feature handlers (references, workspace/symbol, rename, type hierarchy, didDeleteFiles)

--- a/sls/src/org/scala/abusers/sls/ServerImpl.scala
+++ b/sls/src/org/scala/abusers/sls/ServerImpl.scala
@@ -9,7 +9,6 @@ import cats.syntax.all.*
 import fs2.io.file.Files
 import fs2.io.process.ProcessBuilder
 import fs2.text
-import index.value
 import io.scalaland.chimney.dsl._
 import io.scalaland.chimney.javacollections._
 import io.scalaland.chimney.Transformer
@@ -377,20 +376,13 @@ class ServerImpl(
         info      <- bspStateManager.get(uri)
         pc        <- pcProvider.get(info)
         defResult <- IO.interruptible(pc.definition(offsetParams))
-        pcSymbol   = defResult.symbol()
-        baseName   = index.semanticDbToFullName(pcSymbol)
-        candidates = index.symbolIdCandidates(baseName)
-        _    <- IO(logger.info(s"References: pcSymbol=$pcSymbol, candidates=${candidates.map(_.value)}"))
-        refs <- candidates.foldLeft(IO.pure(List.empty[index.SymbolReference])) { (acc, id) =>
-          acc.flatMap(prev =>
-            symbolIndex.getReferences(id).map { r =>
-              logger.info(s"References for ${id.value}: ${r.size} refs")
-              prev ++ r
-            }
-          )
-        }
-        _ <- symbolIndex.project.debugReferenceKeys.flatMap(keys =>
-          IO(logger.info(s"All reference keys in index (${keys.size}): ${keys.take(20).map(_.value)}"))
+        pcSymbol = defResult.symbol()
+        targetId = index.SymbolId.fromSemanticDb(pcSymbol)
+        _    <- IO(logger.info(s"References: pcSymbol=$pcSymbol, targetId=${targetId.render}"))
+        refs <- symbolIndex.getReferences(targetId)
+        _    <- IO(logger.info(s"References for ${targetId.render}: ${refs.size} refs"))
+        _    <- symbolIndex.project.debugReferenceKeys.flatMap(keys =>
+          IO(logger.info(s"All reference keys in index (${keys.size}): ${keys.take(20).map(_.render)}"))
         )
       } yield lsp.TextDocumentReferencesOpOutput(
         if refs.isEmpty then None
@@ -459,10 +451,10 @@ class ServerImpl(
 
   private def toDebugSymbol(s: index.IndexedSymbol): DebugSymbol =
     DebugSymbol(
-      id = s.id.value,
+      id = s.id.render,
       name = s.name,
       kind = s.kind.toString,
-      owner = s.owner.map(_.value),
+      owner = s.owner.map(_.render),
       origin = Some(s.origin match {
         case index.SymbolOrigin.ProjectTasty(bt, uri)      => s"project:$bt ($uri)"
         case index.SymbolOrigin.ProjectJavaSource(bt, uri) => s"project-java:$bt ($uri)"

--- a/sls/src/org/scala/abusers/sls/index/BytecodeIndexer.scala
+++ b/sls/src/org/scala/abusers/sls/index/BytecodeIndexer.scala
@@ -55,8 +55,11 @@ class BytecodeIndexer {
 private class IndexClassVisitor(origin: SymbolOrigin) extends ClassVisitor(Opcodes.ASM9) {
   val symbols: ListBuffer[IndexedSymbol] = ListBuffer.empty
 
-  private var className: String       = ""
-  private var classSymbolId: SymbolId = SymbolId("")
+  /** JVM internal name (e.g. `crossproducer/Lib$Inner` or `crossproducer/Lib$`). Passed through `SymbolId.fromJvm` to
+    * produce canonical ids; kept verbatim so methods/fields can be built off the same internal name.
+    */
+  private var internalName: String    = ""
+  private var classSymbolId: SymbolId = SymbolId.tpe(Nil, Nil, "")
   override def visit(
       version: Int,
       access: Int,
@@ -65,26 +68,25 @@ private class IndexClassVisitor(origin: SymbolOrigin) extends ClassVisitor(Opcod
       superName: String,
       interfaces: Array[String],
   ): Unit = {
-    className = jvmToFqn(name)
-    classSymbolId = SymbolId(className)
+    internalName = name
+    classSymbolId = SymbolId.fromJvm(name, memberName = None)
 
     if (shouldSkipClass(name, access)) return
 
-    val kind       = classKind(name, access)
-    val vis        = accessToVisibility(access)
-    val parents    = buildParents(superName, interfaces)
-    val simpleName = className.split("[.$]").filter(_.nonEmpty).last
+    val kind    = classKind(name, access)
+    val vis     = accessToVisibility(access)
+    val parents = buildParents(superName, interfaces)
 
     symbols += IndexedSymbol(
       id = classSymbolId,
-      name = simpleName,
+      name = classSymbolId.name,
       kind = kind,
       visibility = vis,
-      owner = ownerFromFqn(className),
+      owner = ownerFromInternalName(name),
       location = None,
       origin = origin,
       parents = parents,
-      typeSignature = Some(className),
+      typeSignature = Some(classSymbolId.render),
     )
   }
 
@@ -99,7 +101,7 @@ private class IndexClassVisitor(origin: SymbolOrigin) extends ClassVisitor(Opcod
 
     val kind     = if (name == "<init>") SymbolKind.Constructor else SymbolKind.Method
     val vis      = accessToVisibility(access)
-    val methodId = SymbolId(s"$className#$name")
+    val methodId = SymbolId.fromJvm(internalName, memberName = Some(name))
     val sig      = Option(signature).getOrElse(descriptor)
 
     symbols += IndexedSymbol(
@@ -130,7 +132,7 @@ private class IndexClassVisitor(origin: SymbolOrigin) extends ClassVisitor(Opcod
       if ((access & Opcodes.ACC_ENUM) != 0) SymbolKind.EnumCase
       else if ((access & Opcodes.ACC_FINAL) != 0) SymbolKind.Val
       else SymbolKind.Var
-    val fieldId = SymbolId(s"$className#$name")
+    val fieldId = SymbolId.fromJvm(internalName, memberName = Some(name))
     val sig     = Option(signature).getOrElse(descriptor)
 
     symbols += IndexedSymbol(
@@ -181,24 +183,30 @@ private class IndexClassVisitor(origin: SymbolOrigin) extends ClassVisitor(Opcod
   private def isBridge(access: Int): Boolean =
     (access & Opcodes.ACC_BRIDGE) != 0
 
-  private def jvmToFqn(internalName: String): String =
-    internalName.replace('/', '.')
-
   private def buildParents(superName: String, interfaces: Array[String]): List[SymbolId] = {
     val parents = ListBuffer.empty[SymbolId]
     if (superName != null && superName != "java/lang/Object")
-      parents += SymbolId(jvmToFqn(superName))
+      parents += SymbolId.fromJvm(superName, memberName = None)
     if (interfaces != null)
-      interfaces.foreach(i => parents += SymbolId(jvmToFqn(i)))
+      interfaces.foreach(i => parents += SymbolId.fromJvm(i, memberName = None))
     parents.toList
   }
 
-  private def ownerFromFqn(fqn: String): Option[SymbolId] = {
-    val lastDollar = fqn.lastIndexOf('$')
-    val lastDot    = fqn.lastIndexOf('.')
-    val sep        = math.max(lastDollar, lastDot)
-    if (sep > 0) Some(SymbolId(fqn.substring(0, sep)))
-    else None
+  /** Owner of a class is its lexically-enclosing class for inner classes, otherwise None. We deliberately do *not*
+    * encode the package as the owner — packages are not types in our canonical model.
+    */
+  private def ownerFromInternalName(name: String): Option[SymbolId] = {
+    val lastSlash = name.lastIndexOf('/')
+    // Trailing `$` on a class name means the module class itself; strip it before looking for an outer.
+    val core      = if (name.endsWith("$")) name.dropRight(1) else name
+    val classPart =
+      if (lastSlash >= 0) core.substring(lastSlash + 1) else core
+    val lastDollar = classPart.lastIndexOf('$')
+    if (lastDollar > 0) {
+      val pkgPart   = if (lastSlash >= 0) name.substring(0, lastSlash + 1) else ""
+      val ownerName = pkgPart + classPart.substring(0, lastDollar)
+      Some(SymbolId.fromJvm(ownerName, memberName = None))
+    } else None
   }
 }
 

--- a/sls/src/org/scala/abusers/sls/index/DepIndexCache.scala
+++ b/sls/src/org/scala/abusers/sls/index/DepIndexCache.scala
@@ -76,7 +76,7 @@ class DepIndexCache(root: Path) {
 object DepIndexCache {
 
   /** Bump on any breaking change to the cached IndexedSymbol JSON shape or to the indexer's extraction logic. */
-  val Version: Int = 2
+  val Version: Int = 3
 
   def default: DepIndexCache =
     new DepIndexCache(XdgCacheDir.cacheHome.resolve("sls/dep-index"))

--- a/sls/src/org/scala/abusers/sls/index/IndexTypes.scala
+++ b/sls/src/org/scala/abusers/sls/index/IndexTypes.scala
@@ -29,7 +29,9 @@ case class SymbolId(
   def render: String = {
     val parts = pkg ++ owners
     val base  = if parts.isEmpty then name else (parts :+ name).mkString(".")
-    member.fold(base)(_ => base + "()")
+    // Terms render with parens; the inside carries the overload disambig once Phase 2 starts setting it.
+    // Empty parens on vals/objects look a bit odd but keep type-vs-term distinguishable in debug output.
+    member.fold(base)(m => s"$base(${m.disambig.getOrElse("")})")
   }
   override def toString: String = render
 }

--- a/sls/src/org/scala/abusers/sls/index/IndexTypes.scala
+++ b/sls/src/org/scala/abusers/sls/index/IndexTypes.scala
@@ -2,39 +2,124 @@ package org.scala.abusers.sls.index
 
 import org.scala.abusers.sls.SourceUri
 
-opaque type SymbolId = String
-
-object SymbolId {
-  def apply(value: String): SymbolId = value
+/** Canonical, producer-agnostic symbol identifier.
+  *
+  * Replaces the prior opaque-string form whose value drifted by producer: TASTy emitted `Cls.foo`, bytecode emitted
+  * `Cls#foo`. The case-class form has every producer go through one of the `from*` factories, so the *same*
+  * source-level symbol turns into the *same* `SymbolId` regardless of who saw it.
+  *
+  * Shape:
+  *   - `pkg` — package segments, root-to-leaf (e.g. `List("scala", "collection")`)
+  *   - `owners` — outer class/object chain inside the package (e.g. `List("List")` for `List.foo`)
+  *   - `name` — simple name of this symbol
+  *   - `member` — `None` for types (class/trait/enum/typealias/typeparam/package), `Some` for terms
+  *     (method/val/var/object/given/enum-case/constructor/field)
+  *
+  * Phase 1 deliberately *omits* member kind and overload disambig (`Member.disambig = None`). The plan documents the
+  * trade-off: overloaded methods coalesce to one id (find-references returns all overloads), and a class's `val x` and
+  * `def x` would also coalesce (the language already forbids that combo, so it bites nothing). Promote to an
+  * erased-arg-list disambig if real users complain.
+  */
+case class SymbolId(
+    pkg: List[String],
+    owners: List[String],
+    name: String,
+    member: Option[Member],
+) {
+  def render: String = {
+    val parts = pkg ++ owners
+    val base  = if parts.isEmpty then name else (parts :+ name).mkString(".")
+    member.fold(base)(_ => base + "()")
+  }
+  override def toString: String = render
 }
 
-extension (id: SymbolId) def value: String = id
+case class Member(disambig: Option[String])
+object Member {
 
-/** Converts a SemanticDB symbol (e.g. `scala/collection/immutable/List#`) to the dotted fullName format used by TASTy
-  * (e.g. `scala.collection.immutable.List`).
-  */
-def semanticDbToFullName(sdbSymbol: String): String =
-  sdbSymbol
-    .replaceAll("\\(\\+?\\d*\\)", "")
-    .stripSuffix("#")
-    .stripSuffix(".")
-    .replace("#", ".")
-    .replace("/", ".")
+  /** The Phase 1 default: a term with no overload disambig. */
+  val term: Member = Member(None)
+}
 
-/** Generate candidate SymbolIds for a dotted name, covering the class/object ambiguity. TASTy uses `$` suffix for
-  * objects (e.g. `Test$`), but SemanticDB doesn't. For `com.example.Test.dupa`, we also try `com.example.Test$.dupa`.
-  */
-def symbolIdCandidates(dottedName: String): List[SymbolId] = {
-  val base    = SymbolId(dottedName)
-  val lastDot = dottedName.lastIndexOf('.')
-  if lastDot <= 0 then List(base)
-  else {
-    val ownerEnd = dottedName.lastIndexOf('.', lastDot - 1)
-    if ownerEnd <= 0 then List(base)
-    else {
-      val owner      = dottedName.substring(ownerEnd + 1, lastDot)
-      val withDollar = dottedName.substring(0, ownerEnd + 1) + owner + "$" + dottedName.substring(lastDot)
-      List(base, SymbolId(withDollar)).distinct
+object SymbolId {
+
+  /** Type-level id (class, trait, enum-type, type alias, type param, package). */
+  def tpe(pkg: List[String], owners: List[String], name: String): SymbolId =
+    SymbolId(pkg, owners, name, None)
+
+  /** Term-level id (method, val, var, object, given, enum case, constructor, field). */
+  def term(pkg: List[String], owners: List[String], name: String): SymbolId =
+    SymbolId(pkg, owners, name, Some(Member.term))
+
+  /** TASTy-flavoured input: caller has already decomposed `Symbol.owner` into a package chain + outer-class chain,
+    * extracted the simple name, and decided type-vs-term from the symbol's flags.
+    */
+  def fromTasty(pkg: List[String], owners: List[String], name: String, isType: Boolean): SymbolId =
+    if isType then tpe(pkg, owners, name) else term(pkg, owners, name)
+
+  /** Java symbols (via the Java frontend driver) flow through the same dotty `Symbol` API as TASTy. */
+  def fromJava(pkg: List[String], owners: List[String], name: String, isType: Boolean): SymbolId =
+    fromTasty(pkg, owners, name, isType)
+
+  /** JVM bytecode input. `jvmInternalClass` is the slash-separated internal name (e.g. `crossproducer/Lib$Inner` or
+    * `crossproducer/Lib$` for an object's module class). `memberName`:
+    *   - `None` on a trailing-`$` class → TERM id (the object companion)
+    *   - `None` otherwise → TYPE id (the class)
+    *   - `Some(name)` → TERM id rooted at the class's canonical owner chain, regardless of `$` suffix
+    */
+  def fromJvm(jvmInternalClass: String, memberName: Option[String]): SymbolId = {
+    val dotted              = jvmInternalClass.replace('/', '.')
+    val lastDot             = dotted.lastIndexOf('.')
+    val (pkgStr, classPath) =
+      if lastDot >= 0 then (dotted.substring(0, lastDot), dotted.substring(lastDot + 1))
+      else ("", dotted)
+    val pkg = if pkgStr.isEmpty then Nil else pkgStr.split('.').toList
+
+    val endsWithDollar       = classPath.endsWith("$")
+    val core                 = if endsWithDollar then classPath.dropRight(1) else classPath
+    val classSegments        = core.split('$').toList.filter(_.nonEmpty)
+    val (clsOwners, clsName) = classSegments match {
+      case Nil  => (Nil, "")
+      case many => (many.init, many.last)
+    }
+    memberName match {
+      case None    =>
+        if endsWithDollar then term(pkg, clsOwners, clsName)
+        else tpe(pkg, clsOwners, clsName)
+      case Some(m) =>
+        term(pkg, clsOwners :+ clsName, m)
+    }
+  }
+
+  /** SemanticDB input. Parses strings like `scala/Predef.println(+1).` or `crossproducer/Lib#compute().`. Drops the
+    * overload disambig `(+N)` since Phase 1 coalesces overloads (see class docstring).
+    *
+    * Separator rules:
+    *   - `/` between package segments
+    *   - `.` / `#` between class/owner segments (we don't preserve which is which — owners are just names)
+    *   - trailing `#` ⇒ type, trailing `.` ⇒ term
+    */
+  def fromSemanticDb(sdbSymbol: String): SymbolId = {
+    val cleaned             = sdbSymbol.replaceAll("\\(\\+?\\d*\\)", "")
+    val lastSlash           = cleaned.lastIndexOf('/')
+    val (pkgStr, classPart) =
+      if lastSlash >= 0 then (cleaned.substring(0, lastSlash), cleaned.substring(lastSlash + 1))
+      else ("", cleaned)
+    val pkg = if pkgStr.isEmpty then Nil else pkgStr.split('/').toList
+
+    val isType =
+      if classPart.endsWith("#") then true
+      else false // `.` or anything else falls through as term — bare strings are rare and best treated as terms
+
+    val core   = classPart.stripSuffix("#").stripSuffix(".")
+    val tokens = core.split("[.#]").toList.filter(_.nonEmpty)
+    tokens match {
+      case Nil       => SymbolId(pkg, Nil, "", None)
+      case List(one) => if isType then tpe(pkg, Nil, one) else term(pkg, Nil, one)
+      case many      =>
+        val name   = many.last
+        val owners = many.init
+        if isType then tpe(pkg, owners, name) else term(pkg, owners, name)
     }
   }
 }

--- a/sls/src/org/scala/abusers/sls/index/IndexedSymbolCodecs.scala
+++ b/sls/src/org/scala/abusers/sls/index/IndexedSymbolCodecs.scala
@@ -6,18 +6,17 @@ import org.scala.abusers.sls.SourceUri
 
 object IndexedSymbolCodecs {
 
-  given JsonValueCodec[SymbolId] = new JsonValueCodec[SymbolId] {
-    def decodeValue(in: JsonReader, default: SymbolId): SymbolId = SymbolId(in.readString(null))
-    def encodeValue(x: SymbolId, out: JsonWriter): Unit          = out.writeVal(x.value)
-    def nullValue: SymbolId                                      = null.asInstanceOf[SymbolId]
-  }
-
+  /** SourceUri is opaque-over-String, so still needs an explicit codec — JsonCodecMaker can't derive opaque types. */
   given JsonValueCodec[SourceUri] = new JsonValueCodec[SourceUri] {
     def decodeValue(in: JsonReader, default: SourceUri): SourceUri = SourceUri(in.readString(null))
     def encodeValue(x: SourceUri, out: JsonWriter): Unit           = out.writeVal(x.toLspUri)
     def nullValue: SourceUri                                       = null.asInstanceOf[SourceUri]
   }
 
+  /** SymbolId / Member are case classes; JsonCodecMaker derives a structural object codec automatically through the
+    * top-level `List[IndexedSymbol]` codec below. The on-disk format is JSON objects, not opaque strings — a breaking
+    * change vs. Phase 0. [[DepIndexCache.Version]] is bumped to invalidate old caches.
+    */
   given JsonValueCodec[List[IndexedSymbol]] = JsonCodecMaker.make(
     CodecMakerConfig.withDiscriminatorFieldName(Some("_kind"))
   )

--- a/sls/src/org/scala/abusers/sls/index/JavaIndexer.scala
+++ b/sls/src/org/scala/abusers/sls/index/JavaIndexer.scala
@@ -259,11 +259,39 @@ private class JavaSymbolCollector(originFor: SourceUri => SymbolOrigin) extends 
     else Visibility.Public
   }
 
-  private def symbolId(sym: Symbol)(using Context): SymbolId = SymbolId(sym.fullName.toString)
+  private def symbolId(sym: Symbol)(using Context): SymbolId = {
+    val isType        = isTypeLike(sym)
+    val name          = stripDollar(sym.name.toString)
+    val (pkg, owners) = collectOwners(sym.owner)
+    SymbolId.fromJava(pkg, owners, name, isType)
+  }
+
+  private def isTypeLike(sym: Symbol)(using Context): Boolean =
+    if sym.is(Flags.Package) then true
+    else if sym.is(Flags.Module) then false
+    else sym.isType
+
+  private def collectOwners(start: Symbol)(using Context): (List[String], List[String]) = {
+    val ownersBuf  = mutable.ListBuffer.empty[String]
+    val packageBuf = mutable.ListBuffer.empty[String]
+    var cur        = start
+    while (cur.exists && !cur.isRoot && !cur.is(Flags.Package)) {
+      ownersBuf.prepend(stripDollar(cur.name.toString))
+      cur = cur.owner
+    }
+    while (cur.exists && !cur.isRoot && cur.is(Flags.Package)) {
+      packageBuf.prepend(stripDollar(cur.name.toString))
+      cur = cur.owner
+    }
+    (packageBuf.toList, ownersBuf.toList)
+  }
+
+  private def stripDollar(n: String): String =
+    if n.endsWith("$") then n.dropRight(1) else n
 
   private def ownerId(sym: Symbol)(using Context): Option[SymbolId] = {
     val o = sym.owner
-    if !o.exists || o.isRoot then None else Some(symbolId(o))
+    if !o.exists || o.isRoot || o.is(Flags.Package) then None else Some(symbolId(o))
   }
 
   private def sourceUri(sym: Symbol)(using Context): Option[SourceUri] = {

--- a/sls/src/org/scala/abusers/sls/index/ProjectIndex.scala
+++ b/sls/src/org/scala/abusers/sls/index/ProjectIndex.scala
@@ -189,7 +189,7 @@ object ProjectIndex {
     var refsMap = s.references
     newRefs.foreach { ref =>
       logger.info(
-        s"  addRef: ${ref.symbol.value} -> ${ref.location.uri}:${ref.location.startLine}:${ref.location.startCol} (${ref.referenceKind})"
+        s"  addRef: ${ref.symbol.render} -> ${ref.location.uri}:${ref.location.startLine}:${ref.location.startCol} (${ref.referenceKind})"
       )
       refsMap = refsMap.updatedWith(ref.symbol) {
         case Some(list) => Some(ref :: list)

--- a/sls/src/org/scala/abusers/sls/index/SemanticdbIndexer.scala
+++ b/sls/src/org/scala/abusers/sls/index/SemanticdbIndexer.scala
@@ -26,7 +26,7 @@ object SemanticdbIndexer {
           endLine = r.endLine,
           endCol = r.endCharacter,
         )
-        val symId = SymbolId(semanticDbToFullName(occ.symbol))
+        val symId = SymbolId.fromSemanticDb(occ.symbol)
 
         if occ.role.isDefinition then {
           val info = symbolInfos.get(occ.symbol)

--- a/sls/src/org/scala/abusers/sls/index/TastyIndexer.scala
+++ b/sls/src/org/scala/abusers/sls/index/TastyIndexer.scala
@@ -345,7 +345,7 @@ private class SymbolCollector(buildTarget: String) extends scala.tasty.inspector
       } catch {
         case NonFatal(_) =>
           try SymbolId.fromTasty(Nil, Nil, stripDollar(sym.name), isType = false)
-          catch { case NonFatal(_) => SymbolId(Nil, Nil, "<unknown>", None) }
+          catch { case NonFatal(_) => SymbolId.tpe(Nil, Nil, "<unknown>") }
       }
 
     /** Type vs term decision. Packages are types; objects (Module flag) are terms even though their module-class is

--- a/sls/src/org/scala/abusers/sls/index/TastyIndexer.scala
+++ b/sls/src/org/scala/abusers/sls/index/TastyIndexer.scala
@@ -337,12 +337,57 @@ private class SymbolCollector(buildTarget: String) extends scala.tasty.inspector
       } catch { case NonFatal(_) => () }
 
     def mkSymbolId(sym: Symbol): SymbolId =
-      SymbolId(
-        try sym.fullName
-        catch {
-          case NonFatal(_) => sym.name
-        }
-      )
+      try {
+        val isType        = isTypeLike(sym)
+        val name          = stripDollar(sym.name)
+        val (pkg, owners) = collectOwners(sym.maybeOwner)
+        SymbolId.fromTasty(pkg, owners, name, isType)
+      } catch {
+        case NonFatal(_) =>
+          try SymbolId.fromTasty(Nil, Nil, stripDollar(sym.name), isType = false)
+          catch { case NonFatal(_) => SymbolId(Nil, Nil, "<unknown>", None) }
+      }
+
+    /** Type vs term decision. Packages are types; objects (Module flag) are terms even though their module-class is
+      * structurally a class; everything else falls back to dotty's class/type/val/def classifiers.
+      */
+    def isTypeLike(sym: Symbol): Boolean = {
+      val flags = sym.flags
+      if flags.is(Flags.Package) then true
+      else if flags.is(Flags.Module) then false
+      else if sym.isClassDef || sym.isTypeDef then true
+      else false
+    }
+
+    /** Walk the owner chain, collecting type-level owners until the first package, then package segments until root.
+      * The returned lists are root-to-leaf.
+      */
+    def collectOwners(start: Symbol): (List[String], List[String]) = {
+      val ownersBuf  = scala.collection.mutable.ListBuffer.empty[String]
+      val packageBuf = scala.collection.mutable.ListBuffer.empty[String]
+      var cur        = start
+      while (!isStopSymbol(cur) && !cur.flags.is(Flags.Package)) {
+        ownersBuf.prepend(stripDollar(cur.name))
+        cur = cur.maybeOwner
+      }
+      while (!isStopSymbol(cur)) {
+        packageBuf.prepend(stripDollar(cur.name))
+        cur = cur.maybeOwner
+      }
+      (packageBuf.toList, ownersBuf.toList)
+    }
+
+    def isStopSymbol(sym: Symbol): Boolean =
+      sym.isNoSymbol || {
+        val n = sym.name
+        n == "<root>" || n == "_root_" || n == "<empty>" || n.isEmpty
+      }
+
+    /** Module-class symbols carry a trailing `$` in some dotty paths; strip it so class `Lib` and object `Lib`'s
+      * owner-name agree.
+      */
+    def stripDollar(n: String): String =
+      if n.endsWith("$") then n.dropRight(1) else n
 
     def sourceFileUri(sym: Symbol): Option[SourceUri] =
       try {

--- a/sls/test/src/org/scala/abusers/sls/index/BytecodeIndexerSpec.scala
+++ b/sls/test/src/org/scala/abusers/sls/index/BytecodeIndexerSpec.scala
@@ -149,7 +149,7 @@ object BytecodeIndexerSpec extends SimpleIOSuite {
       jar  <- createJar(List(outer, inner))
       syms <- indexer.indexJar(jar)
       innerSym = syms.find(_.name == "Inner")
-    } yield expect(innerSym.exists(_.owner.contains(SymbolId("com.example.Outer"))))
+    } yield expect(innerSym.exists(_.owner.contains(IndexTestFixtures.tid("com.example.Outer"))))
   }
 
   test("parent classes extracted") {
@@ -159,10 +159,10 @@ object BytecodeIndexerSpec extends SimpleIOSuite {
     for {
       jar  <- createJar(List(base, child))
       syms <- indexer.indexJar(jar)
-      childSym = syms.find(_.id == SymbolId("com.example.Child"))
+      childSym = syms.find(_.id == IndexTestFixtures.tid("com.example.Child"))
       parents  = childSym.toList.flatMap(_.parents)
-    } yield expect(parents.contains(SymbolId("com.example.Base"))) and
-      expect(parents.contains(SymbolId("java.io.Serializable")))
+    } yield expect(parents.contains(IndexTestFixtures.tid("com.example.Base"))) and
+      expect(parents.contains(IndexTestFixtures.tid("java.io.Serializable")))
   }
 
   test("all symbols have location = None and DependencyClassfile origin") {

--- a/sls/test/src/org/scala/abusers/sls/index/CrossProducerSpec.scala
+++ b/sls/test/src/org/scala/abusers/sls/index/CrossProducerSpec.scala
@@ -3,21 +3,17 @@ package org.scala.abusers.sls.index
 import cats.effect.IO
 import weaver.*
 
-/** Verifies that TastyIndexer, BytecodeIndexer, and JavaIndexer emit the same SymbolId
-  * for the same source-level symbols in the cross-producer fixture (`crossProducerFixture`).
+/** Verifies that TastyIndexer, BytecodeIndexer, and JavaIndexer emit the same SymbolId for the same source-level
+  * symbols in the cross-producer fixture (`crossProducerFixture`).
   *
-  * The fixture JAR is pre-compiled and published to `~/.m2` by `sls.test.forkArgs` — see
-  * `IndexTestFixtures`. No runtime compilation.
+  * The fixture JAR is pre-compiled and published to `~/.m2` by `sls.test.forkArgs` — see `IndexTestFixtures`. No
+  * runtime compilation.
   *
-  * All assertions are ignored until Phase 1 fixes the `Cls.foo` vs `Cls#foo` id mismatch.
-  * When Phase 1 is complete, delete each `ignore(...)` line and watch the tests go green.
-  * The fixture covers: top-level class, companion object, overloaded methods, inner class.
+  * Phase 1 exit signal: these assertions used to be `ignore(...)`'d because TastyIndexer emitted
+  * `crossproducer.Lib.compute` while BytecodeIndexer emitted `crossproducer.Lib#compute`. The canonical [[SymbolId]]
+  * removes that drift; the tests run for real now.
   */
 object CrossProducerSpec extends SimpleIOSuite {
-
-  private val pendingReason =
-    "pending until Phase 1: TastyIndexer emits crossproducer.Lib.compute, " +
-      "BytecodeIndexer emits crossproducer.Lib#compute — canonical SymbolId required"
 
   private def tastySymbols: IO[List[IndexedSymbol]] =
     TastyIndexer("test").indexJar(IndexTestFixtures.crossProducerJar, Nil).map(_.values.flatMap(_._1).toList)
@@ -34,69 +30,54 @@ object CrossProducerSpec extends SimpleIOSuite {
   // ── Top-level class ──────────────────────────────────────────────────────────
 
   test("top-level class id agrees between TastyIndexer and BytecodeIndexer") {
-    ignore(pendingReason) *> {
-      for {
-        tastyIds    <- tastySymbols.map(_.map(_.id).toSet)
-        bytecodeIds <- bytecodeSymbols.map(_.map(_.id).toSet)
-        libId = SymbolId("crossproducer.Lib")
-      } yield expect(tastyIds.contains(libId)) and expect(bytecodeIds.contains(libId))
-    }
+    for {
+      tastyIds    <- tastySymbols.map(_.map(_.id).toSet)
+      bytecodeIds <- bytecodeSymbols.map(_.map(_.id).toSet)
+      libId = SymbolId.tpe(List("crossproducer"), Nil, "Lib")
+    } yield expect(tastyIds.contains(libId)) and expect(bytecodeIds.contains(libId))
   }
 
   test("companion object id agrees between TastyIndexer and BytecodeIndexer") {
-    ignore(pendingReason) *> {
-      for {
-        tastyIds    <- tastySymbols.map(_.map(_.id).toSet)
-        bytecodeIds <- bytecodeSymbols.map(_.map(_.id).toSet)
-        // Both should converge on crossproducer.Lib (module Object kind, no $ in canonical form)
-        libObjId = SymbolId("crossproducer.Lib")
-      } yield expect(tastyIds.exists(_ == libObjId)) and expect(bytecodeIds.exists(_ == libObjId))
-    }
+    for {
+      tastyIds    <- tastySymbols.map(_.map(_.id).toSet)
+      bytecodeIds <- bytecodeSymbols.map(_.map(_.id).toSet)
+      // Companion object is a TERM (the singleton value), distinct from the class id of the same name.
+      libObjId = SymbolId.term(List("crossproducer"), Nil, "Lib")
+    } yield expect(tastyIds.contains(libObjId)) and expect(bytecodeIds.contains(libObjId))
   }
 
   test("overloaded method compute(Int) id agrees between TastyIndexer and BytecodeIndexer") {
     // Phase 1 exit signal: canonical example of the Cls.foo vs Cls#foo bug.
-    // TastyIndexer: crossproducer.Lib.compute  BytecodeIndexer: crossproducer.Lib#compute
-    ignore(pendingReason) *> {
-      for {
-        tastyIds    <- tastySymbols.map(_.map(_.id).toSet)
-        bytecodeIds <- bytecodeSymbols.map(_.map(_.id).toSet)
-        computeId = SymbolId("crossproducer.Lib.compute")
-      } yield expect(tastyIds.contains(computeId)) and expect(bytecodeIds.contains(computeId))
-    }
+    for {
+      tastyIds    <- tastySymbols.map(_.map(_.id).toSet)
+      bytecodeIds <- bytecodeSymbols.map(_.map(_.id).toSet)
+      computeId = SymbolId.term(List("crossproducer"), List("Lib"), "compute")
+    } yield expect(tastyIds.contains(computeId)) and expect(bytecodeIds.contains(computeId))
   }
 
   test("inner class id agrees between TastyIndexer and BytecodeIndexer") {
-    ignore(pendingReason) *> {
-      for {
-        tastyIds    <- tastySymbols.map(_.map(_.id).toSet)
-        bytecodeIds <- bytecodeSymbols.map(_.map(_.id).toSet)
-        innerId = SymbolId("crossproducer.Lib.Inner")
-      } yield expect(tastyIds.contains(innerId)) and expect(bytecodeIds.contains(innerId))
-    }
+    for {
+      tastyIds    <- tastySymbols.map(_.map(_.id).toSet)
+      bytecodeIds <- bytecodeSymbols.map(_.map(_.id).toSet)
+      innerId = SymbolId.tpe(List("crossproducer"), List("Lib"), "Inner")
+    } yield expect(tastyIds.contains(innerId)) and expect(bytecodeIds.contains(innerId))
   }
 
   // ── Java vs. Bytecode ────────────────────────────────────────────────────────
 
   test("Java class LibJ id agrees between JavaIndexer and BytecodeIndexer") {
-    ignore(pendingReason) *> {
-      for {
-        javaIds     <- javaSymbols.map(_.map(_.id).toSet)
-        bytecodeIds <- bytecodeSymbols.map(_.map(_.id).toSet)
-        libJId = SymbolId("crossproducer.LibJ")
-      } yield expect(javaIds.contains(libJId)) and expect(bytecodeIds.contains(libJId))
-    }
+    for {
+      javaIds     <- javaSymbols.map(_.map(_.id).toSet)
+      bytecodeIds <- bytecodeSymbols.map(_.map(_.id).toSet)
+      libJId = SymbolId.tpe(List("crossproducer"), Nil, "LibJ")
+    } yield expect(javaIds.contains(libJId)) and expect(bytecodeIds.contains(libJId))
   }
 
   test("Java overloaded method id agrees between JavaIndexer and BytecodeIndexer") {
-    // JavaIndexer uses sym.fullName → crossproducer.LibJ.compute
-    // BytecodeIndexer uses JVM format → crossproducer.LibJ#compute
-    ignore(pendingReason) *> {
-      for {
-        javaIds     <- javaSymbols.map(_.map(_.id).toSet)
-        bytecodeIds <- bytecodeSymbols.map(_.map(_.id).toSet)
-        computeId = SymbolId("crossproducer.LibJ.compute")
-      } yield expect(javaIds.contains(computeId)) and expect(bytecodeIds.contains(computeId))
-    }
+    for {
+      javaIds     <- javaSymbols.map(_.map(_.id).toSet)
+      bytecodeIds <- bytecodeSymbols.map(_.map(_.id).toSet)
+      computeId = SymbolId.term(List("crossproducer"), List("LibJ"), "compute")
+    } yield expect(javaIds.contains(computeId)) and expect(bytecodeIds.contains(computeId))
   }
 }

--- a/sls/test/src/org/scala/abusers/sls/index/DepIndexCacheSpec.scala
+++ b/sls/test/src/org/scala/abusers/sls/index/DepIndexCacheSpec.scala
@@ -9,14 +9,14 @@ import java.nio.file.Files
 object DepIndexCacheSpec extends SimpleIOSuite {
 
   private def sample(name: String): IndexedSymbol = IndexedSymbol(
-    id = SymbolId(s"com.example.$name"),
+    id = IndexTestFixtures.tid(s"com.example.$name"),
     name = name,
     kind = SymbolKind.Class,
     visibility = Visibility.Public,
     owner = None,
     location = Some(Location(SourceUri("jar:file:///foo.jar!/Foo.java"), 1, 0, 10, 1)),
     origin = SymbolOrigin.DependencySource("/path/to/foo-1.0.0.jar", SourceUri("jar:file:///foo.jar!/Foo.java")),
-    parents = List(SymbolId("java.lang.Object")),
+    parents = List(IndexTestFixtures.tid("java.lang.Object")),
     typeSignature = Some(s"com.example.$name"),
   )
 

--- a/sls/test/src/org/scala/abusers/sls/index/DependencyIndexSpec.scala
+++ b/sls/test/src/org/scala/abusers/sls/index/DependencyIndexSpec.scala
@@ -15,7 +15,7 @@ object DependencyIndexSpec extends SimpleIOSuite {
       location: Option[Location] = None,
   ): IndexedSymbol =
     IndexedSymbol(
-      id = SymbolId(s"pkg.$name"),
+      id = IndexTestFixtures.tid(s"pkg.$name"),
       name = name,
       kind = SymbolKind.Class,
       visibility = Visibility.Public,
@@ -30,7 +30,7 @@ object DependencyIndexSpec extends SimpleIOSuite {
     for {
       idx    <- DependencyIndex.empty
       _      <- idx.addJar(jarA, List(sym("Foo", jarA)))
-      result <- idx.getSymbol(SymbolId("pkg.Foo"))
+      result <- idx.getSymbol(IndexTestFixtures.tid("pkg.Foo"))
     } yield expect(result.exists(_.name == "Foo"))
   }
 
@@ -73,43 +73,43 @@ object DependencyIndexSpec extends SimpleIOSuite {
     for {
       idx    <- DependencyIndex.empty
       _      <- idx.addJar(jarA, List(sym("Foo", jarA)))
-      before <- idx.getSymbol(SymbolId("pkg.Foo"))
+      before <- idx.getSymbol(IndexTestFixtures.tid("pkg.Foo"))
       loc = Location(SourceUri("file:///src/Foo.scala"), 10, 0, 10, 20)
-      _     <- idx.updateLocations(Map(SymbolId("pkg.Foo") -> loc))
-      after <- idx.getSymbol(SymbolId("pkg.Foo"))
+      _     <- idx.updateLocations(Map(IndexTestFixtures.tid("pkg.Foo") -> loc))
+      after <- idx.getSymbol(IndexTestFixtures.tid("pkg.Foo"))
     } yield expect(before.flatMap(_.location).isEmpty) and
       expect(after.flatMap(_.location).contains(loc))
   }
 
   test("getSubtypes works across JARs") {
     val parent = sym("Parent", jarA)
-    val childA = sym("ChildA", jarA, parents = List(SymbolId("pkg.Parent")))
-    val childB = sym("ChildB", jarB, parents = List(SymbolId("pkg.Parent")))
+    val childA = sym("ChildA", jarA, parents = List(IndexTestFixtures.tid("pkg.Parent")))
+    val childB = sym("ChildB", jarB, parents = List(IndexTestFixtures.tid("pkg.Parent")))
     for {
       idx  <- DependencyIndex.empty
       _    <- idx.addJar(jarA, List(parent, childA))
       _    <- idx.addJar(jarB, List(childB))
-      subs <- idx.getSubtypes(SymbolId("pkg.Parent"))
-    } yield expect(subs == Set(SymbolId("pkg.ChildA"), SymbolId("pkg.ChildB")))
+      subs <- idx.getSubtypes(IndexTestFixtures.tid("pkg.Parent"))
+    } yield expect(subs == Set(IndexTestFixtures.tid("pkg.ChildA"), IndexTestFixtures.tid("pkg.ChildB")))
   }
 
   test("getSupertypes returns parents") {
-    val child = sym("Child", jarA, parents = List(SymbolId("pkg.Parent")))
+    val child = sym("Child", jarA, parents = List(IndexTestFixtures.tid("pkg.Parent")))
     for {
       idx     <- DependencyIndex.empty
       _       <- idx.addJar(jarA, List(child))
-      parents <- idx.getSupertypes(SymbolId("pkg.Child"))
-    } yield expect(parents == List(SymbolId("pkg.Parent")))
+      parents <- idx.getSupertypes(IndexTestFixtures.tid("pkg.Child"))
+    } yield expect(parents == List(IndexTestFixtures.tid("pkg.Parent")))
   }
 
   test("empty index returns empty for all queries") {
     for {
       idx    <- DependencyIndex.empty
-      sym    <- idx.getSymbol(SymbolId("x"))
+      sym    <- idx.getSymbol(IndexTestFixtures.tid("x"))
       byName <- idx.getSymbolsByName("x")
       search <- idx.searchSymbols("x")
-      subs   <- idx.getSubtypes(SymbolId("x"))
-      supers <- idx.getSupertypes(SymbolId("x"))
+      subs   <- idx.getSubtypes(IndexTestFixtures.tid("x"))
+      supers <- idx.getSupertypes(IndexTestFixtures.tid("x"))
       bloom  <- idx.jarMightContain("any.jar", "x")
     } yield expect(sym.isEmpty) and expect(byName.isEmpty) and expect(search.isEmpty) and
       expect(subs.isEmpty) and expect(supers.isEmpty) and expect(!bloom)

--- a/sls/test/src/org/scala/abusers/sls/index/IndexManagerSpec.scala
+++ b/sls/test/src/org/scala/abusers/sls/index/IndexManagerSpec.scala
@@ -43,7 +43,7 @@ object IndexManagerSpec extends SimpleIOSuite {
   test("onFilesDeleted removes symbols from project index") {
     val uri = SourceUri("file:///test/Foo.scala")
     val sym = IndexedSymbol(
-      id = SymbolId("test.Foo"),
+      id = IndexTestFixtures.tid("test.Foo"),
       name = "Foo",
       kind = SymbolKind.Class,
       visibility = Visibility.Public,
@@ -59,9 +59,9 @@ object IndexManagerSpec extends SimpleIOSuite {
       di <- DependencyIndex.empty
       mgr = IndexManager(pi, di, bytecodeIndexer)
       _      <- pi.updateFiles(Map(uri -> (List(sym), Nil)))
-      before <- pi.getSymbol(SymbolId("test.Foo"))
+      before <- pi.getSymbol(IndexTestFixtures.tid("test.Foo"))
       _      <- mgr.onFilesDeleted(Set(uri))
-      after  <- pi.getSymbol(SymbolId("test.Foo"))
+      after  <- pi.getSymbol(IndexTestFixtures.tid("test.Foo"))
     } yield expect(before.isDefined) and expect(after.isEmpty)
   }
 
@@ -104,7 +104,7 @@ object IndexManagerSpec extends SimpleIOSuite {
   test("searchSymbols with various query styles finds symbols") {
     val uri = SourceUri("file:///test/HashMap.scala")
     val sym = IndexedSymbol(
-      id = SymbolId("scala.collection.HashMap"),
+      id = IndexTestFixtures.tid("scala.collection.HashMap"),
       name = "HashMap",
       kind = SymbolKind.Class,
       visibility = Visibility.Public,
@@ -133,7 +133,7 @@ object IndexManagerSpec extends SimpleIOSuite {
   test("SymbolIndex.searchSymbols finds project and dependency symbols") {
     val uri     = SourceUri("file:///test/Foo.scala")
     val projSym = IndexedSymbol(
-      id = SymbolId("test.Foo"),
+      id = IndexTestFixtures.tid("test.Foo"),
       name = "Foo",
       kind = SymbolKind.Class,
       visibility = Visibility.Public,
@@ -165,7 +165,7 @@ object IndexManagerSpec extends SimpleIOSuite {
   test("CamelCase query 'IO' does not match camelCase 'indexOf'") {
     val uri = SourceUri("file:///test/Stuff.scala")
     val sym = IndexedSymbol(
-      id = SymbolId("test.indexOf"),
+      id = IndexTestFixtures.tid("test.indexOf"),
       name = "indexOf",
       kind = SymbolKind.Method,
       visibility = Visibility.Public,
@@ -188,7 +188,7 @@ object IndexManagerSpec extends SimpleIOSuite {
   test("mixed case 'iO' matches camelCase 'iOnly' via name prefix") {
     val uri = SourceUri("file:///test/Stuff.scala")
     val sym = IndexedSymbol(
-      id = SymbolId("test.iOnly"),
+      id = IndexTestFixtures.tid("test.iOnly"),
       name = "iOnly",
       kind = SymbolKind.Method,
       visibility = Visibility.Public,
@@ -211,7 +211,7 @@ object IndexManagerSpec extends SimpleIOSuite {
   test("lowercase query 'minutes' matches all-caps 'MINUTES'") {
     val uri = SourceUri("file:///test/Constants.scala")
     val sym = IndexedSymbol(
-      id = SymbolId("java.util.concurrent.TimeUnit.MINUTES"),
+      id = IndexTestFixtures.tid("java.util.concurrent.TimeUnit.MINUTES"),
       name = "MINUTES",
       kind = SymbolKind.Field,
       visibility = Visibility.Public,
@@ -235,7 +235,7 @@ object IndexManagerSpec extends SimpleIOSuite {
     val uri1 = SourceUri("file:///test/A.scala")
     val uri2 = SourceUri("file:///test/B.scala")
     val sym1 = IndexedSymbol(
-      id = SymbolId("test.A"),
+      id = IndexTestFixtures.tid("test.A"),
       name = "A",
       kind = SymbolKind.Class,
       visibility = Visibility.Public,
@@ -246,7 +246,7 @@ object IndexManagerSpec extends SimpleIOSuite {
       typeSignature = None,
     )
     val sym2 = IndexedSymbol(
-      id = SymbolId("test.B"),
+      id = IndexTestFixtures.tid("test.B"),
       name = "B",
       kind = SymbolKind.Class,
       visibility = Visibility.Public,
@@ -268,8 +268,8 @@ object IndexManagerSpec extends SimpleIOSuite {
         )
       )
       _ <- mgr.onFilesDeleted(Set(uri1, uri2))
-      a <- pi.getSymbol(SymbolId("test.A"))
-      b <- pi.getSymbol(SymbolId("test.B"))
+      a <- pi.getSymbol(IndexTestFixtures.tid("test.A"))
+      b <- pi.getSymbol(IndexTestFixtures.tid("test.B"))
     } yield expect(a.isEmpty) and expect(b.isEmpty)
   }
 

--- a/sls/test/src/org/scala/abusers/sls/index/IndexTestFixtures.scala
+++ b/sls/test/src/org/scala/abusers/sls/index/IndexTestFixtures.scala
@@ -6,9 +6,8 @@ import java.nio.file.Paths
 
 /** Coordinates and resolved JAR paths for the index test fixtures.
   *
-  * System properties are injected by `sls.test.forkArgs` in `build.mill`, which also
-  * publishes the fixtures to `~/.m2` (`publishM2LocalCached`) before tests fork. Pattern
-  * mirrors the VirtusLab/cellar fixture approach.
+  * System properties are injected by `sls.test.forkArgs` in `build.mill`, which also publishes the fixtures to `~/.m2`
+  * (`publishM2LocalCached`) before tests fork. Pattern mirrors the VirtusLab/cellar fixture approach.
   */
 object IndexTestFixtures {
 
@@ -19,6 +18,7 @@ object IndexTestFixtures {
   }
 
   final case class Coord(group: String, artifact: String, version: String) {
+
     /** Absolute path of the published JAR inside the local M2 repository. */
     def jarPath(localM2: String): AbsolutePath = {
       val groupDir = group.replace('.', '/')
@@ -29,19 +29,50 @@ object IndexTestFixtures {
   lazy val localM2: String = require("sls.test.localM2")
 
   lazy val crossProducerCoord: Coord = Coord(
-    group    = require("sls.test.crossProducerGroup"),
+    group = require("sls.test.crossProducerGroup"),
     artifact = require("sls.test.crossProducerArtifact"),
-    version  = require("sls.test.crossProducerVersion"),
+    version = require("sls.test.crossProducerVersion"),
   )
 
   lazy val tastyIndexerCoord: Coord = Coord(
-    group    = require("sls.test.tastyIndexerGroup"),
+    group = require("sls.test.tastyIndexerGroup"),
     artifact = require("sls.test.tastyIndexerArtifact"),
-    version  = require("sls.test.tastyIndexerVersion"),
+    version = require("sls.test.tastyIndexerVersion"),
   )
 
-  lazy val crossProducerJar: AbsolutePath  = crossProducerCoord.jarPath(localM2)
-  lazy val tastyIndexerJar: AbsolutePath   = tastyIndexerCoord.jarPath(localM2)
+  lazy val crossProducerJar: AbsolutePath     = crossProducerCoord.jarPath(localM2)
+  lazy val tastyIndexerJar: AbsolutePath      = tastyIndexerCoord.jarPath(localM2)
   lazy val crossProducerLibJSrc: AbsolutePath =
     AbsolutePath(Paths.get(require("sls.test.crossProducerLibJSrc")))
+
+  /** Test-only canonical-id builder. Parses a dotted name into a [[SymbolId]] under the assumption that all but the
+    * final segment are packages (no nested classes/owners) and the final segment is the symbol name. Use the explicit
+    * overload for owner/member structure when needed.
+    *
+    * tid("crossproducer.Lib") == SymbolId.tpe(List("crossproducer"), Nil, "Lib") tid("crossproducer.pkg.Foo") ==
+    * SymbolId.tpe(List("crossproducer", "pkg"), Nil, "Foo")
+    */
+  def tid(dotted: String): SymbolId = {
+    val parts = dotted.split('.').toList.filter(_.nonEmpty)
+    parts match {
+      case Nil       => SymbolId.tpe(Nil, Nil, "")
+      case List(one) => SymbolId.tpe(Nil, Nil, one)
+      case many      => SymbolId.tpe(many.init, Nil, many.last)
+    }
+  }
+
+  /** Term-id counterpart to [[tid]]: the final segment is treated as a term (method/val/etc.) and the segment before it
+    * as its owning class/object.
+    *
+    * mid("crossproducer.Lib.compute") == SymbolId.term(List("crossproducer"), List("Lib"), "compute")
+    */
+  def mid(dotted: String): SymbolId = {
+    val parts = dotted.split('.').toList.filter(_.nonEmpty)
+    parts match {
+      case Nil        => SymbolId.term(Nil, Nil, "")
+      case List(one)  => SymbolId.term(Nil, Nil, one)
+      case List(a, b) => SymbolId.term(Nil, List(a), b)
+      case many       => SymbolId.term(many.init.init, List(many.init.last), many.last)
+    }
+  }
 }

--- a/sls/test/src/org/scala/abusers/sls/index/IndexTypesSpec.scala
+++ b/sls/test/src/org/scala/abusers/sls/index/IndexTypesSpec.scala
@@ -5,15 +5,55 @@ import weaver.*
 
 object IndexTypesSpec extends SimpleIOSuite {
 
-  test("SymbolId round-trips through .value") {
-    val id = SymbolId("scala/Option#")
-    IO(expect(SymbolId(id.value) == id))
+  test("SymbolId equality is structural") {
+    val a = SymbolId.tpe(List("a"), Nil, "B")
+    val b = SymbolId.tpe(List("a"), Nil, "B")
+    val c = SymbolId.tpe(List("a"), Nil, "C")
+    IO(expect(a == b) && expect(a != c))
   }
 
-  test("SymbolId equality") {
+  test("type vs term ids with the same name are not equal") {
+    val tpeId  = SymbolId.tpe(List("crossproducer"), Nil, "Lib")
+    val termId = SymbolId.term(List("crossproducer"), Nil, "Lib")
+    IO(expect(tpeId != termId))
+  }
+
+  test("fromJvm parses a top-level class") {
+    val id = SymbolId.fromJvm("crossproducer/Lib", memberName = None)
+    IO(expect(id == SymbolId.tpe(List("crossproducer"), Nil, "Lib")))
+  }
+
+  test("fromJvm parses a method on a top-level class") {
+    val id = SymbolId.fromJvm("crossproducer/Lib", memberName = Some("compute"))
+    IO(expect(id == SymbolId.term(List("crossproducer"), List("Lib"), "compute")))
+  }
+
+  test("fromJvm strips trailing $ on a module class into a term id") {
+    val id = SymbolId.fromJvm("crossproducer/Lib$", memberName = None)
+    IO(expect(id == SymbolId.term(List("crossproducer"), Nil, "Lib")))
+  }
+
+  test("fromJvm handles inner classes") {
+    val id = SymbolId.fromJvm("com/example/Outer$Inner", memberName = None)
+    IO(expect(id == SymbolId.tpe(List("com", "example"), List("Outer"), "Inner")))
+  }
+
+  test("fromSemanticDb parses a type symbol") {
+    val id = SymbolId.fromSemanticDb("scala/collection/immutable/List#")
+    IO(expect(id == SymbolId.tpe(List("scala", "collection", "immutable"), Nil, "List")))
+  }
+
+  test("fromSemanticDb parses a term member on a class") {
+    val id = SymbolId.fromSemanticDb("scala/Predef.println(+1).")
+    IO(expect(id == SymbolId.term(List("scala"), List("Predef"), "println")))
+  }
+
+  test("render produces a stable human-readable string") {
+    val cls   = SymbolId.tpe(List("crossproducer"), Nil, "Lib")
+    val mthod = SymbolId.term(List("crossproducer"), List("Lib"), "compute")
     IO(
-      expect(SymbolId("a.B#") == SymbolId("a.B#")) &&
-        expect(SymbolId("a.B#") != SymbolId("a.C#"))
+      expect(cls.render == "crossproducer.Lib") &&
+        expect(mthod.render == "crossproducer.Lib.compute()")
     )
   }
 }

--- a/sls/test/src/org/scala/abusers/sls/index/IndexTypesSpec.scala
+++ b/sls/test/src/org/scala/abusers/sls/index/IndexTypesSpec.scala
@@ -48,6 +48,26 @@ object IndexTypesSpec extends SimpleIOSuite {
     IO(expect(id == SymbolId.term(List("scala"), List("Predef"), "println")))
   }
 
+  test("fromSemanticDb collapses `.` and `#` separators in the owner chain") {
+    // Lock-in for the Phase 1 simplification documented on `fromSemanticDb`: owner separators are not preserved,
+    // so an inner-class term symbol coalesces to the same id regardless of which form the SemanticDB writer chose.
+    val a = SymbolId.fromSemanticDb("pkg/Outer.Inner#run().")
+    val b = SymbolId.fromSemanticDb("pkg/Outer#Inner.run().")
+    IO(
+      expect(a == SymbolId.term(List("pkg"), List("Outer", "Inner"), "run")) &&
+        expect(a == b)
+    )
+  }
+
+  test("fromJava routes through fromTasty and respects the isType flag") {
+    val cls    = SymbolId.fromJava(List("pkg"), Nil, "LibJ", isType = true)
+    val method = SymbolId.fromJava(List("pkg"), List("LibJ"), "compute", isType = false)
+    IO(
+      expect(cls == SymbolId.tpe(List("pkg"), Nil, "LibJ")) &&
+        expect(method == SymbolId.term(List("pkg"), List("LibJ"), "compute"))
+    )
+  }
+
   test("render produces a stable human-readable string") {
     val cls   = SymbolId.tpe(List("crossproducer"), Nil, "Lib")
     val mthod = SymbolId.term(List("crossproducer"), List("Lib"), "compute")
@@ -55,5 +75,10 @@ object IndexTypesSpec extends SimpleIOSuite {
       expect(cls.render == "crossproducer.Lib") &&
         expect(mthod.render == "crossproducer.Lib.compute()")
     )
+  }
+
+  test("render includes Member.disambig once it's set (Phase 2 forward-compat)") {
+    val overloaded = SymbolId(List("pkg"), List("Lib"), "compute", Some(Member(Some("(I)I"))))
+    IO(expect(overloaded.render == "pkg.Lib.compute((I)I)"))
   }
 }

--- a/sls/test/src/org/scala/abusers/sls/index/JavaIndexerSpec.scala
+++ b/sls/test/src/org/scala/abusers/sls/index/JavaIndexerSpec.scala
@@ -39,7 +39,7 @@ object JavaIndexerSpec extends SimpleIOSuite {
     for {
       syms <- allSymbols
       areaOnSquare = syms.find(s =>
-        s.name == "area" && s.kind == SymbolKind.Method && s.owner.exists(_ == SymbolId("fixture.Square"))
+        s.name == "area" && s.kind == SymbolKind.Method && s.owner.exists(_ == IndexTestFixtures.tid("fixture.Square"))
       )
     } yield expect(areaOnSquare.isDefined)
   }
@@ -59,17 +59,17 @@ object JavaIndexerSpec extends SimpleIOSuite {
     for {
       syms <- allSymbols
       ctors = syms.filter(_.kind == SymbolKind.Constructor)
-    } yield expect(ctors.exists(_.owner.exists(_.value.contains("Square"))))
+    } yield expect(ctors.exists(_.owner.exists(_.render.contains("Square"))))
   }
 
   test("implements relationship produces parent + Extends reference") {
     for {
       syms <- allSymbols
       refs <- allRefs
-      square      = syms.find(_.id == SymbolId("fixture.Square"))
+      square      = syms.find(_.id == IndexTestFixtures.tid("fixture.Square"))
       extendsRefs = refs.filter(_.referenceKind == ReferenceKind.Extends)
-    } yield expect(square.exists(_.parents.contains(SymbolId("fixture.Shapes")))) and
-      expect(extendsRefs.exists(_.symbol == SymbolId("fixture.Shapes")))
+    } yield expect(square.exists(_.parents.contains(IndexTestFixtures.tid("fixture.Shapes")))) and
+      expect(extendsRefs.exists(_.symbol == IndexTestFixtures.tid("fixture.Shapes")))
   }
 
   test("origin is ProjectJavaSource") {
@@ -127,12 +127,12 @@ object JavaIndexerSpec extends SimpleIOSuite {
       serial   <- indexer.indexJarEntries(zip, Nil, parallelism = 1)
       parallel <- indexer.indexJarEntries(zip, Nil, parallelism = 4)
     } yield {
-      val serialSyms   = serial.values.flatMap(_._1).map(_.id.value).toSet
-      val parallelSyms = parallel.values.flatMap(_._1).map(_.id.value).toSet
+      val serialSyms   = serial.values.flatMap(_._1).map(_.id).toSet
+      val parallelSyms = parallel.values.flatMap(_._1).map(_.id).toSet
       expect(serialSyms == parallelSyms) and
-        expect(parallelSyms.contains("com.a.Alpha")) and
-        expect(parallelSyms.contains("com.a.Beta")) and
-        expect(parallelSyms.contains("com.b.Gamma"))
+        expect(parallelSyms.contains(IndexTestFixtures.tid("com.a.Alpha"))) and
+        expect(parallelSyms.contains(IndexTestFixtures.tid("com.a.Beta"))) and
+        expect(parallelSyms.contains(IndexTestFixtures.tid("com.b.Gamma")))
     }
   }
 
@@ -166,8 +166,8 @@ object JavaIndexerSpec extends SimpleIOSuite {
     }.flatMap { zip =>
       JavaIndexer.forDependency(zip.toNioPath.toString).indexJarEntries(zip, Nil).map { results =>
         val syms = results.values.flatMap(_._1).toList
-        expect(syms.exists(_.id.value == "java.lang.FakeClass")) and
-          expect(!syms.exists(_.id.value.contains("module-info")))
+        expect(syms.exists(_.id == IndexTestFixtures.tid("java.lang.FakeClass"))) and
+          expect(!syms.exists(_.id.render.contains("module-info")))
       }
     }
   }

--- a/sls/test/src/org/scala/abusers/sls/index/ProjectIndexSpec.scala
+++ b/sls/test/src/org/scala/abusers/sls/index/ProjectIndexSpec.scala
@@ -11,7 +11,7 @@ object ProjectIndexSpec extends SimpleIOSuite {
 
   private def sym(name: String, file: SourceUri, parents: List[SymbolId] = Nil): IndexedSymbol =
     IndexedSymbol(
-      id = SymbolId(s"pkg.$name"),
+      id = IndexTestFixtures.tid(s"pkg.$name"),
       name = name,
       kind = SymbolKind.Class,
       visibility = Visibility.Public,
@@ -24,7 +24,7 @@ object ProjectIndexSpec extends SimpleIOSuite {
 
   private def ref(symbolName: String, file: SourceUri): SymbolReference =
     SymbolReference(
-      symbol = SymbolId(s"pkg.$symbolName"),
+      symbol = IndexTestFixtures.tid(s"pkg.$symbolName"),
       location = Location(file, 5, 0, 5, 10),
       referenceKind = ReferenceKind.Call,
     )
@@ -33,7 +33,7 @@ object ProjectIndexSpec extends SimpleIOSuite {
     for {
       idx    <- ProjectIndex.empty
       _      <- idx.updateFiles(Map(fileA -> (List(sym("Foo", fileA)), Nil)))
-      result <- idx.getSymbol(SymbolId("pkg.Foo"))
+      result <- idx.getSymbol(IndexTestFixtures.tid("pkg.Foo"))
     } yield expect(result.exists(_.name == "Foo"))
   }
 
@@ -63,8 +63,8 @@ object ProjectIndexSpec extends SimpleIOSuite {
         )
       )
       _   <- idx.removeFiles(Set(fileA))
-      foo <- idx.getSymbol(SymbolId("pkg.Foo"))
-      bar <- idx.getSymbol(SymbolId("pkg.Bar"))
+      foo <- idx.getSymbol(IndexTestFixtures.tid("pkg.Foo"))
+      bar <- idx.getSymbol(IndexTestFixtures.tid("pkg.Bar"))
     } yield expect(foo.isEmpty) and expect(bar.isDefined)
   }
 
@@ -73,8 +73,8 @@ object ProjectIndexSpec extends SimpleIOSuite {
       idx <- ProjectIndex.empty
       _   <- idx.updateFiles(Map(fileA -> (List(sym("Foo", fileA)), Nil)))
       _   <- idx.updateFiles(Map(fileA -> (List(sym("Baz", fileA)), Nil)))
-      foo <- idx.getSymbol(SymbolId("pkg.Foo"))
-      baz <- idx.getSymbol(SymbolId("pkg.Baz"))
+      foo <- idx.getSymbol(IndexTestFixtures.tid("pkg.Foo"))
+      baz <- idx.getSymbol(IndexTestFixtures.tid("pkg.Baz"))
     } yield expect(foo.isEmpty) and expect(baz.isDefined)
   }
 
@@ -103,55 +103,55 @@ object ProjectIndexSpec extends SimpleIOSuite {
           fileB -> (Nil, List(ref("Bar", fileB))),
         )
       )
-      result <- idx.getReferences(SymbolId("pkg.Bar"))
+      result <- idx.getReferences(IndexTestFixtures.tid("pkg.Bar"))
     } yield expect(result.size == 2)
   }
 
   test("getReferences returns every inserted ref, with no loss or duplication") {
-    val r1 = SymbolReference(SymbolId("pkg.T"), Location(fileA, 1, 0, 1, 5), ReferenceKind.Call)
-    val r2 = SymbolReference(SymbolId("pkg.T"), Location(fileA, 2, 0, 2, 5), ReferenceKind.Call)
-    val r3 = SymbolReference(SymbolId("pkg.T"), Location(fileA, 3, 0, 3, 5), ReferenceKind.Call)
+    val r1 = SymbolReference(IndexTestFixtures.tid("pkg.T"), Location(fileA, 1, 0, 1, 5), ReferenceKind.Call)
+    val r2 = SymbolReference(IndexTestFixtures.tid("pkg.T"), Location(fileA, 2, 0, 2, 5), ReferenceKind.Call)
+    val r3 = SymbolReference(IndexTestFixtures.tid("pkg.T"), Location(fileA, 3, 0, 3, 5), ReferenceKind.Call)
     for {
       idx  <- ProjectIndex.empty
       _    <- idx.updateFiles(Map(fileA -> (Nil, List(r1, r2, r3))))
-      refs <- idx.getReferences(SymbolId("pkg.T"))
+      refs <- idx.getReferences(IndexTestFixtures.tid("pkg.T"))
     } yield expect(refs.size == 3) and expect(refs.toSet == Set(r1, r2, r3))
   }
 
   test("updateFiles replaces — not appends — refs for the same URI") {
     // A second updateFiles for the same URI must remove old refs before inserting new.
     // Without removal, repeated compile events accumulate stale references.
-    val old = SymbolReference(SymbolId("pkg.T"), Location(fileA, 1, 0, 1, 5), ReferenceKind.Call)
-    val neu = SymbolReference(SymbolId("pkg.T"), Location(fileA, 9, 0, 9, 5), ReferenceKind.Call)
+    val old = SymbolReference(IndexTestFixtures.tid("pkg.T"), Location(fileA, 1, 0, 1, 5), ReferenceKind.Call)
+    val neu = SymbolReference(IndexTestFixtures.tid("pkg.T"), Location(fileA, 9, 0, 9, 5), ReferenceKind.Call)
     for {
       idx  <- ProjectIndex.empty
       _    <- idx.updateFiles(Map(fileA -> (Nil, List(old))))
       _    <- idx.updateFiles(Map(fileA -> (Nil, List(neu))))
-      refs <- idx.getReferences(SymbolId("pkg.T"))
+      refs <- idx.getReferences(IndexTestFixtures.tid("pkg.T"))
     } yield expect(refs.size == 1) and expect(refs.head.location.startLine == 9)
   }
 
   test("getSubtypes correct after insertion and clean after removal") {
     val parent = sym("Parent", fileA)
-    val child  = sym("Child", fileA, parents = List(SymbolId("pkg.Parent")))
+    val child  = sym("Child", fileA, parents = List(IndexTestFixtures.tid("pkg.Parent")))
     for {
       idx       <- ProjectIndex.empty
       _         <- idx.updateFiles(Map(fileA -> (List(parent, child), Nil)))
-      subs      <- idx.getSubtypes(SymbolId("pkg.Parent"))
+      subs      <- idx.getSubtypes(IndexTestFixtures.tid("pkg.Parent"))
       _         <- idx.removeFiles(Set(fileA))
-      subsAfter <- idx.getSubtypes(SymbolId("pkg.Parent"))
-    } yield expect(subs == Set(SymbolId("pkg.Child"))) and expect(subsAfter.isEmpty)
+      subsAfter <- idx.getSubtypes(IndexTestFixtures.tid("pkg.Parent"))
+    } yield expect(subs == Set(IndexTestFixtures.tid("pkg.Child"))) and expect(subsAfter.isEmpty)
   }
 
   test("empty index returns empty for all queries") {
     for {
       idx    <- ProjectIndex.empty
-      sym    <- idx.getSymbol(SymbolId("x"))
+      sym    <- idx.getSymbol(IndexTestFixtures.tid("x"))
       byName <- idx.getSymbolsByName("x")
       search <- idx.searchSymbols("x")
       inFile <- idx.getSymbolsInFile(fileA)
-      refs   <- idx.getReferences(SymbolId("x"))
-      subs   <- idx.getSubtypes(SymbolId("x"))
+      refs   <- idx.getReferences(IndexTestFixtures.tid("x"))
+      subs   <- idx.getSubtypes(IndexTestFixtures.tid("x"))
     } yield expect(sym.isEmpty) and expect(byName.isEmpty) and expect(search.isEmpty) and
       expect(inFile.isEmpty) and expect(refs.isEmpty) and expect(subs.isEmpty)
   }

--- a/sls/test/src/org/scala/abusers/sls/index/SymbolIndexSpec.scala
+++ b/sls/test/src/org/scala/abusers/sls/index/SymbolIndexSpec.scala
@@ -18,7 +18,7 @@ object SymbolIndexSpec extends SimpleIOSuite {
       endCol: Int = 10,
   ): IndexedSymbol =
     IndexedSymbol(
-      id = SymbolId(s"pkg.$name"),
+      id = IndexTestFixtures.tid(s"pkg.$name"),
       name = name,
       kind = kind,
       visibility = Visibility.Public,
@@ -35,7 +35,7 @@ object SymbolIndexSpec extends SimpleIOSuite {
       kind: SymbolKind = SymbolKind.Class,
   ): IndexedSymbol =
     IndexedSymbol(
-      id = SymbolId(s"pkg.$name"),
+      id = IndexTestFixtures.tid(s"pkg.$name"),
       name = name,
       kind = kind,
       visibility = Visibility.Public,
@@ -63,14 +63,14 @@ object SymbolIndexSpec extends SimpleIOSuite {
   test("symbol in project only → found") {
     for {
       idx    <- mkIndex(projSyms = List(projSym("Foo")))
-      result <- idx.getSymbol(SymbolId("pkg.Foo"))
+      result <- idx.getSymbol(IndexTestFixtures.tid("pkg.Foo"))
     } yield expect(result.exists(_.name == "Foo"))
   }
 
   test("symbol in dependency only → found") {
     for {
       idx    <- mkIndex(depSyms = List(depSym("Bar")))
-      result <- idx.getSymbol(SymbolId("pkg.Bar"))
+      result <- idx.getSymbol(IndexTestFixtures.tid("pkg.Bar"))
     } yield expect(result.exists(_.name == "Bar"))
   }
 
@@ -79,7 +79,7 @@ object SymbolIndexSpec extends SimpleIOSuite {
     val dep  = depSym("Foo")
     for {
       idx    <- mkIndex(projSyms = List(proj), depSyms = List(dep))
-      result <- idx.getSymbol(SymbolId("pkg.Foo"))
+      result <- idx.getSymbol(IndexTestFixtures.tid("pkg.Foo"))
     } yield expect(result.exists(_.origin.isInstanceOf[SymbolOrigin.ProjectTasty]))
   }
 
@@ -101,31 +101,31 @@ object SymbolIndexSpec extends SimpleIOSuite {
   }
 
   test("getReferences returns only project references") {
-    val r = SymbolReference(SymbolId("pkg.Bar"), Location(fileA, 5, 0, 5, 10), ReferenceKind.Call)
+    val r = SymbolReference(IndexTestFixtures.tid("pkg.Bar"), Location(fileA, 5, 0, 5, 10), ReferenceKind.Call)
     for {
       idx    <- mkIndex(projRefs = List(r))
-      result <- idx.getReferences(SymbolId("pkg.Bar"))
+      result <- idx.getReferences(IndexTestFixtures.tid("pkg.Bar"))
     } yield expect(result.size == 1)
   }
 
   test("getSubtypes merges from both tiers") {
     val projParent = projSym("Parent")
-    val projChild  = projSym("ChildA", parents = List(SymbolId("pkg.Parent")))
-    val depChild   = depSym("ChildB", parents = List(SymbolId("pkg.Parent")))
+    val projChild  = projSym("ChildA", parents = List(IndexTestFixtures.tid("pkg.Parent")))
+    val depChild   = depSym("ChildB", parents = List(IndexTestFixtures.tid("pkg.Parent")))
     for {
       idx  <- mkIndex(projSyms = List(projParent, projChild), depSyms = List(depChild))
-      subs <- idx.getSubtypes(SymbolId("pkg.Parent"))
-    } yield expect(subs == Set(SymbolId("pkg.ChildA"), SymbolId("pkg.ChildB")))
+      subs <- idx.getSubtypes(IndexTestFixtures.tid("pkg.Parent"))
+    } yield expect(subs == Set(IndexTestFixtures.tid("pkg.ChildA"), IndexTestFixtures.tid("pkg.ChildB")))
   }
 
   test("getImplementations follows transitive subtype chain") {
     // Trait -> Abstract -> Concrete
     val traitSym    = projSym("MyTrait", kind = SymbolKind.Trait)
-    val abstractSym = projSym("Abstract", parents = List(SymbolId("pkg.MyTrait")), kind = SymbolKind.Trait)
-    val concrete    = projSym("Concrete", parents = List(SymbolId("pkg.Abstract")))
+    val abstractSym = projSym("Abstract", parents = List(IndexTestFixtures.tid("pkg.MyTrait")), kind = SymbolKind.Trait)
+    val concrete    = projSym("Concrete", parents = List(IndexTestFixtures.tid("pkg.Abstract")))
     for {
       idx   <- mkIndex(projSyms = List(traitSym, abstractSym, concrete))
-      impls <- idx.getImplementations(SymbolId("pkg.MyTrait"))
+      impls <- idx.getImplementations(IndexTestFixtures.tid("pkg.MyTrait"))
     } yield expect(impls.size == 1) and expect(impls.head.name == "Concrete")
   }
 
@@ -148,11 +148,11 @@ object SymbolIndexSpec extends SimpleIOSuite {
   }
 
   test("getSupertypes uses project-priority symbol") {
-    val proj = projSym("Child", parents = List(SymbolId("pkg.ProjParent")))
-    val dep  = depSym("Child", parents = List(SymbolId("pkg.DepParent")))
+    val proj = projSym("Child", parents = List(IndexTestFixtures.tid("pkg.ProjParent")))
+    val dep  = depSym("Child", parents = List(IndexTestFixtures.tid("pkg.DepParent")))
     for {
       idx    <- mkIndex(projSyms = List(proj), depSyms = List(dep))
-      supers <- idx.getSupertypes(SymbolId("pkg.Child"))
-    } yield expect(supers == List(SymbolId("pkg.ProjParent")))
+      supers <- idx.getSupertypes(IndexTestFixtures.tid("pkg.Child"))
+    } yield expect(supers == List(IndexTestFixtures.tid("pkg.ProjParent")))
   }
 }

--- a/sls/test/src/org/scala/abusers/sls/index/TastyIndexerSpec.scala
+++ b/sls/test/src/org/scala/abusers/sls/index/TastyIndexerSpec.scala
@@ -4,8 +4,8 @@ import cats.effect.IO
 import org.scala.abusers.sls.SourceUri
 import weaver.*
 
-/** Indexes the pre-compiled `tastyIndexerFixture` JAR published to `~/.m2` by
-  * `sls.test.forkArgs` — see `IndexTestFixtures`. No dotc at test time.
+/** Indexes the pre-compiled `tastyIndexerFixture` JAR published to `~/.m2` by `sls.test.forkArgs` — see
+  * `IndexTestFixtures`. No dotc at test time.
   */
 object TastyIndexerSpec extends SimpleIOSuite {
 
@@ -26,8 +26,8 @@ object TastyIndexerSpec extends SimpleIOSuite {
 
   test("simple class with method — both symbols extracted") {
     for {
-      cls    <- findById(SymbolId("fixture.SimpleClass"))
-      method <- findById(SymbolId("fixture.SimpleClass.greet"))
+      cls    <- findById(IndexTestFixtures.tid("fixture.SimpleClass"))
+      method <- findById(IndexTestFixtures.mid("fixture.SimpleClass.greet"))
     } yield expect(cls.isDefined) and
       expect(cls.exists(_.kind == SymbolKind.Class)) and
       expect(method.isDefined) and
@@ -36,53 +36,55 @@ object TastyIndexerSpec extends SimpleIOSuite {
 
   test("trait with abstract method — Trait kind") {
     for {
-      sym <- findById(SymbolId("fixture.Animal"))
+      sym <- findById(IndexTestFixtures.tid("fixture.Animal"))
     } yield expect(sym.exists(_.kind == SymbolKind.Trait))
   }
 
   test("case class — class extracted") {
     for {
-      sym <- findById(SymbolId("fixture.Point"))
+      sym <- findById(IndexTestFixtures.tid("fixture.Point"))
     } yield expect(sym.exists(_.kind == SymbolKind.Class))
   }
 
   test("enum with cases — Enum kind and EnumCase kind for each case") {
     for {
-      sym <- findById(SymbolId("fixture.Color"))
+      sym  <- findById(IndexTestFixtures.tid("fixture.Color"))
       syms <- allSymbols
-      red   = syms.find(s => s.name == "Red"   && s.kind == SymbolKind.EnumCase)
+      red   = syms.find(s => s.name == "Red" && s.kind == SymbolKind.EnumCase)
       green = syms.find(s => s.name == "Green" && s.kind == SymbolKind.EnumCase)
-      blue  = syms.find(s => s.name == "Blue"  && s.kind == SymbolKind.EnumCase)
+      blue  = syms.find(s => s.name == "Blue" && s.kind == SymbolKind.EnumCase)
     } yield expect(sym.exists(_.kind == SymbolKind.Enum)) and
       expect(red.isDefined) and expect(green.isDefined) and expect(blue.isDefined)
   }
 
   test("sealed trait children — parent/child relationships") {
     for {
-      circle <- findById(SymbolId("fixture.Circle"))
-      rect   <- findById(SymbolId("fixture.Rectangle"))
-    } yield expect(circle.exists(_.parents.contains(SymbolId("fixture.Shape")))) and
-      expect(rect.exists(_.parents.contains(SymbolId("fixture.Shape"))))
+      circle <- findById(IndexTestFixtures.tid("fixture.Circle"))
+      rect   <- findById(IndexTestFixtures.tid("fixture.Rectangle"))
+    } yield expect(circle.exists(_.parents.contains(IndexTestFixtures.tid("fixture.Shape")))) and
+      expect(rect.exists(_.parents.contains(IndexTestFixtures.tid("fixture.Shape"))))
   }
 
   test("class extending trait — parents list correct") {
     for {
-      sym <- findById(SymbolId("fixture.FriendlyGreeter"))
-    } yield expect(sym.exists(_.parents.contains(SymbolId("fixture.Greeter"))))
+      sym <- findById(IndexTestFixtures.tid("fixture.FriendlyGreeter"))
+    } yield expect(sym.exists(_.parents.contains(IndexTestFixtures.tid("fixture.Greeter"))))
   }
 
   test("method override — Override reference points to overridden symbol") {
     for {
       refs <- allRefs
       overrideRefs = refs.filter(_.referenceKind == ReferenceKind.Override)
-    } yield expect(overrideRefs.exists(_.symbol == SymbolId("fixture.Greeter.greet")))
+    } yield expect(overrideRefs.exists(_.symbol == IndexTestFixtures.mid("fixture.Greeter.greet")))
   }
 
   test("multiple top-level defs — all keyed to same source URI") {
     for {
       result <- indexed
       multiUri = result.find { case (_, (syms, _)) =>
-        syms.exists(_.id == SymbolId("fixture.TopA")) && syms.exists(_.id == SymbolId("fixture.TopB"))
+        syms.exists(_.id == IndexTestFixtures.tid("fixture.TopA")) && syms.exists(
+          _.id == IndexTestFixtures.tid("fixture.TopB")
+        )
       }
     } yield expect(multiUri.isDefined)
   }
@@ -97,9 +99,9 @@ object TastyIndexerSpec extends SimpleIOSuite {
 
   test("visibility — private/protected/public correctly determined") {
     for {
-      secret <- findById(SymbolId("fixture.VisibilityExample.secret"))
-      helper <- findById(SymbolId("fixture.VisibilityExample.helper"))
-      pub    <- findById(SymbolId("fixture.VisibilityExample.publicMethod"))
+      secret <- findById(IndexTestFixtures.mid("fixture.VisibilityExample.secret"))
+      helper <- findById(IndexTestFixtures.mid("fixture.VisibilityExample.helper"))
+      pub    <- findById(IndexTestFixtures.mid("fixture.VisibilityExample.publicMethod"))
     } yield expect(secret.exists(_.visibility == Visibility.Private)) and
       expect(helper.exists(_.visibility == Visibility.Protected)) and
       expect(pub.exists(_.visibility == Visibility.Public))

--- a/tastyIndexerFixture/src/VisibilityExample.scala
+++ b/tastyIndexerFixture/src/VisibilityExample.scala
@@ -1,6 +1,9 @@
 package fixture
+import scala.annotation.unused
 class VisibilityExample {
-  private val secret: Int = 42
-  protected def helper(): Unit = ()
-  def publicMethod(): String = "visible"
+  // `@unused` keeps scalafix's RemoveUnused from stripping this — it exists only so the indexer can
+  // observe a private member's visibility.
+  @unused private val secret: Int = 42
+  protected def helper(): Unit     = ()
+  def publicMethod(): String       = "visible"
 }


### PR DESCRIPTION
## Summary

- Replace the opaque-string `SymbolId` with a case class `SymbolId(pkg, owners, name, member: Option[Member])`; every producer now constructs ids through one of four `SymbolId.from*` factories (`fromTasty` / `fromJava` / `fromJvm` / `fromSemanticDb`). The bytecode `Cls#foo` vs TASTy `Cls.foo` mismatch is resolved for the common cases.
- `CrossProducerSpec` (the Phase 1 exit signal) goes green on all six cases (top-level class, companion object, overloaded method, inner class, Java class, Java overloaded method).
- `DepIndexCache.Version` bumped 2 → 3 to invalidate pre-Phase-1 caches; the on-disk codec switches from a custom string-encoded `SymbolId` to a JsonCodecMaker-derived structural codec.

## Test plan

- [x] `./mill __.compile` clean
- [x] `./mill _.test` — 598/598 green
- [x] `./mill __.fix` clean (RemoveUnused; `tastyIndexerFixture/VisibilityExample.scala`'s intentionally-unused `private val secret` now carries `@scala.annotation.unused`)
- [x] CrossProducerSpec's six tests are no longer `ignore(pendingReason)` and pass
- [x] DepIndexCache version bump invalidates any local Phase-0 cache on first run

## Known canonicalization gaps

A high-recall code review surfaced 15 cases where producers still drift or where Phase 0 safety nets were removed. They are intentionally **out of scope for this PR** — the goal here is the structural change, not the long tail of canonicalization edge cases.

Tracked under epic #12:

- High: #64 (`fromJvm` splits `\$` indiscriminately — Scala 3 `\$package`, user `Foo\$Bar`, anonymous classes). Implementation patch attached.
- Medium: #65, #66, #67, #68, #69, #71, #73, #76, #78
- Low: #70, #72, #74, #75, #77

All 15 are orthogonal to Phase 2–6 and can land in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)