### PR TITLE
Fix BytecodeIndexer $-splitting via InnerClasses attribute

### DIFF
--- a/sls/src/org/scala/abusers/sls/index/BytecodeIndexer.scala
+++ b/sls/src/org/scala/abusers/sls/index/BytecodeIndexer.scala
@@ -58,8 +58,17 @@ private class IndexClassVisitor(origin: SymbolOrigin) extends ClassVisitor(Opcod
   /** JVM internal name (e.g. `crossproducer/Lib$Inner` or `crossproducer/Lib$`). Passed through `SymbolId.fromJvm` to
     * produce canonical ids; kept verbatim so methods/fields can be built off the same internal name.
     */
-  private var internalName: String    = ""
-  private var classSymbolId: SymbolId = SymbolId.tpe(Nil, Nil, "")
+  private var internalName: String = ""
+  // Header info captured in `visit`, used in `visitEnd` once `visitInnerClass` has populated innerOuter/innerSimple.
+  private var pendingAccess: Int               = 0
+  private var pendingSuperName: String         = null
+  private var pendingInterfaces: Array[String] = Array.empty
+  private var skipped: Boolean                 = false
+  // InnerClasses attribute entry whose `name` matches this class, if any.
+  private var innerOuter: Option[String]   = None
+  private var innerSimple: Option[String]  = None
+  private var classIdMemo: Option[SymbolId] = None
+
   override def visit(
       version: Int,
       access: Int,
@@ -69,25 +78,34 @@ private class IndexClassVisitor(origin: SymbolOrigin) extends ClassVisitor(Opcod
       interfaces: Array[String],
   ): Unit = {
     internalName = name
-    classSymbolId = SymbolId.fromJvm(name, memberName = None)
+    pendingAccess = access
+    pendingSuperName = superName
+    pendingInterfaces = if (interfaces == null) Array.empty else interfaces
 
-    if (shouldSkipClass(name, access)) return
+    if (shouldSkipClass(name, access)) skipped = true
+  }
 
-    val kind    = classKind(name, access)
-    val vis     = accessToVisibility(access)
-    val parents = buildParents(superName, interfaces)
+  /** ASM invokes this once per record in the class's `InnerClasses` attribute. When the record's `name` matches the
+    * class currently being visited, capture the source-level outer/simple-name pair so id construction can sidestep
+    * the brittle `$`-split heuristic. Anonymous classes have `innerName = null`; skip them outright.
+    */
+  override def visitInnerClass(name: String, outerName: String, innerName: String, access: Int): Unit = {
+    if (name == internalName) {
+      innerOuter = Option(outerName)
+      innerSimple = Option(innerName)
+      if (innerName == null) skipped = true
+    }
+  }
 
-    symbols += IndexedSymbol(
-      id = classSymbolId,
-      name = classSymbolId.name,
-      kind = kind,
-      visibility = vis,
-      owner = ownerFromInternalName(name),
-      location = None,
-      origin = origin,
-      parents = parents,
-      typeSignature = Some(classSymbolId.render),
-    )
+  /** Computed lazily so it sees `innerOuter`/`innerSimple` captured by [[visitInnerClass]] (which ASM invokes after
+    * `visit` but before the first `visitMethod`/`visitField`).
+    */
+  private def classSymbolId(): SymbolId = classIdMemo match {
+    case Some(id) => id
+    case None     =>
+      val id = SymbolId.fromJvm(internalName, memberName = None, innerOuter, innerSimple)
+      classIdMemo = Some(id)
+      id
   }
 
   override def visitMethod(
@@ -97,11 +115,12 @@ private class IndexClassVisitor(origin: SymbolOrigin) extends ClassVisitor(Opcod
       signature: String,
       exceptions: Array[String],
   ): MethodVisitor = {
+    if (skipped) return null
     if (shouldSkipMethod(name, access)) return null
 
     val kind     = if (name == "<init>") SymbolKind.Constructor else SymbolKind.Method
     val vis      = accessToVisibility(access)
-    val methodId = SymbolId.fromJvm(internalName, memberName = Some(name))
+    val methodId = SymbolId.fromJvm(internalName, memberName = Some(name), innerOuter, innerSimple)
     val sig      = Option(signature).getOrElse(descriptor)
 
     symbols += IndexedSymbol(
@@ -109,7 +128,7 @@ private class IndexClassVisitor(origin: SymbolOrigin) extends ClassVisitor(Opcod
       name = name,
       kind = kind,
       visibility = vis,
-      owner = Some(classSymbolId),
+      owner = Some(classSymbolId()),
       location = None,
       origin = origin,
       parents = Nil,
@@ -125,6 +144,7 @@ private class IndexClassVisitor(origin: SymbolOrigin) extends ClassVisitor(Opcod
       signature: String,
       value: AnyRef,
   ): FieldVisitor = {
+    if (skipped) return null
     if (isSynthetic(access)) return null
 
     val vis  = accessToVisibility(access)
@@ -132,7 +152,7 @@ private class IndexClassVisitor(origin: SymbolOrigin) extends ClassVisitor(Opcod
       if ((access & Opcodes.ACC_ENUM) != 0) SymbolKind.EnumCase
       else if ((access & Opcodes.ACC_FINAL) != 0) SymbolKind.Val
       else SymbolKind.Var
-    val fieldId = SymbolId.fromJvm(internalName, memberName = Some(name))
+    val fieldId = SymbolId.fromJvm(internalName, memberName = Some(name), innerOuter, innerSimple)
     val sig     = Option(signature).getOrElse(descriptor)
 
     symbols += IndexedSymbol(
@@ -140,13 +160,32 @@ private class IndexClassVisitor(origin: SymbolOrigin) extends ClassVisitor(Opcod
       name = name,
       kind = kind,
       visibility = vis,
-      owner = Some(classSymbolId),
+      owner = Some(classSymbolId()),
       location = None,
       origin = origin,
       parents = Nil,
       typeSignature = Some(sig),
     )
     null
+  }
+
+  override def visitEnd(): Unit = {
+    if (skipped) return
+    val id      = classSymbolId()
+    val kind    = classKind(internalName, pendingAccess)
+    val vis     = accessToVisibility(pendingAccess)
+    val parents = buildParents(pendingSuperName, pendingInterfaces)
+    symbols += IndexedSymbol(
+      id = id,
+      name = id.name,
+      kind = kind,
+      visibility = vis,
+      owner = innerOuter.map(SymbolId.fromJvm(_, memberName = None)),
+      location = None,
+      origin = origin,
+      parents = parents,
+      typeSignature = Some(id.render),
+    )
   }
 
   private def classKind(name: String, access: Int): SymbolKind = {
@@ -192,22 +231,6 @@ private class IndexClassVisitor(origin: SymbolOrigin) extends ClassVisitor(Opcod
     parents.toList
   }
 
-  /** Owner of a class is its lexically-enclosing class for inner classes, otherwise None. We deliberately do *not*
-    * encode the package as the owner — packages are not types in our canonical model.
-    */
-  private def ownerFromInternalName(name: String): Option[SymbolId] = {
-    val lastSlash = name.lastIndexOf('/')
-    // Trailing `$` on a class name means the module class itself; strip it before looking for an outer.
-    val core      = if (name.endsWith("$")) name.dropRight(1) else name
-    val classPart =
-      if (lastSlash >= 0) core.substring(lastSlash + 1) else core
-    val lastDollar = classPart.lastIndexOf('$')
-    if (lastDollar > 0) {
-      val pkgPart   = if (lastSlash >= 0) name.substring(0, lastSlash + 1) else ""
-      val ownerName = pkgPart + classPart.substring(0, lastDollar)
-      Some(SymbolId.fromJvm(ownerName, memberName = None))
-    } else None
-  }
 }
 
 object BytecodeIndexer {

--- a/sls/src/org/scala/abusers/sls/index/IndexTypes.scala
+++ b/sls/src/org/scala/abusers/sls/index/IndexTypes.scala
@@ -68,28 +68,57 @@ object SymbolId {
     *   - `None` on a trailing-`$` class → TERM id (the object companion)
     *   - `None` otherwise → TYPE id (the class)
     *   - `Some(name)` → TERM id rooted at the class's canonical owner chain, regardless of `$` suffix
+    *
+    * `innerOuterName` and `innerSimpleName` come from ASM's [[org.objectweb.asm.ClassVisitor#visitInnerClass]] for
+    * the currently-visited class, and disambiguate the meaning of `$` in the class name. Without them we cannot
+    * tell `Outer$Inner` (a nested class) apart from a user-written `Foo$Bar` or from the Scala 3 synthetic
+    * `foo$package` top-level wrapper. With them the caller passes the *outer*'s internal name and the *inner*'s
+    * source-simple name directly; we use them and never split on `$`.
+    *
+    * When no inner-class record is supplied (top-level class, `foo$package` wrapper, or `Foo$Bar` user identifier),
+    * the full class segment is treated as a single name — matching what TastyIndexer's `Symbol.name` and
+    * SemanticDB's tokenisation do.
     */
-  def fromJvm(jvmInternalClass: String, memberName: Option[String]): SymbolId = {
+  def fromJvm(
+      jvmInternalClass: String,
+      memberName: Option[String],
+      innerOuterName: Option[String] = None,
+      innerSimpleName: Option[String] = None,
+  ): SymbolId = {
     val dotted              = jvmInternalClass.replace('/', '.')
     val lastDot             = dotted.lastIndexOf('.')
     val (pkgStr, classPath) =
       if lastDot >= 0 then (dotted.substring(0, lastDot), dotted.substring(lastDot + 1))
       else ("", dotted)
-    val pkg = if pkgStr.isEmpty then Nil else pkgStr.split('.').toList
+    val pkg            = if pkgStr.isEmpty then Nil else pkgStr.split('.').toList
+    val endsWithDollar = classPath.endsWith("$")
 
-    val endsWithDollar       = classPath.endsWith("$")
-    val core                 = if endsWithDollar then classPath.dropRight(1) else classPath
-    val classSegments        = core.split('$').toList.filter(_.nonEmpty)
-    val (clsOwners, clsName) = classSegments match {
-      case Nil  => (Nil, "")
-      case many => (many.init, many.last)
-    }
-    memberName match {
-      case None    =>
-        if endsWithDollar then term(pkg, clsOwners, clsName)
-        else tpe(pkg, clsOwners, clsName)
-      case Some(m) =>
-        term(pkg, clsOwners :+ clsName, m)
+    innerOuterName match {
+      case Some(outer) =>
+        // Precise nested-class decomposition from the InnerClasses attribute.
+        val outerId    = fromJvm(outer, memberName = None)
+        val ownersBase = outerId.owners :+ outerId.name
+        val simpleName = innerSimpleName.getOrElse {
+          if endsWithDollar then classPath.dropRight(1) else classPath
+        }
+        memberName match {
+          case None    =>
+            if endsWithDollar then term(pkg, ownersBase, simpleName)
+            else tpe(pkg, ownersBase, simpleName)
+          case Some(m) =>
+            term(pkg, ownersBase :+ simpleName, m)
+        }
+      case None =>
+        // No nested-class record — keep the class segment intact. Covers top-level classes, the Scala 3
+        // `foo$package` top-level wrapper, and user identifiers with literal `$`.
+        val name = if endsWithDollar then classPath.dropRight(1) else classPath
+        memberName match {
+          case None    =>
+            if endsWithDollar then term(pkg, Nil, name)
+            else tpe(pkg, Nil, name)
+          case Some(m) =>
+            term(pkg, List(name), m)
+        }
     }
   }
 

--- a/sls/test/src/org/scala/abusers/sls/index/BytecodeIndexerSpec.scala
+++ b/sls/test/src/org/scala/abusers/sls/index/BytecodeIndexerSpec.scala
@@ -35,10 +35,18 @@ object BytecodeIndexerSpec extends SimpleIOSuite {
       interfaces: Array[String] = null,
       methods: List[(String, String, Int)] = Nil,
       fields: List[(String, String, Int)] = Nil,
+      /** When set, emit an `InnerClasses` attribute record for this class — `(outerInternalName, simpleName)` —
+        * matching what a real compiler produces for a nested class. Pass `None` to omit (the default; correct for
+        * top-level classes).
+        */
+      innerClass: Option[(String, String)] = None,
   ): (String, Array[Byte]) = {
     val cw = new ClassWriter(0)
     cw.visit(Opcodes.V17, access, name, null, superName, interfaces)
     cw.visitSource("Test.java", null)
+    innerClass.foreach { case (outerInternal, simpleName) =>
+      cw.visitInnerClass(name, outerInternal, simpleName, access)
+    }
     methods.foreach { case (mName, desc, mAccess) =>
       val mv = cw.visitMethod(mAccess, mName, desc, null, null)
       mv.visitCode()
@@ -142,14 +150,62 @@ object BytecodeIndexerSpec extends SimpleIOSuite {
     } yield expect(objSym.isDefined)
   }
 
-  test("inner classes attributed to owners") {
+  test("inner classes attributed to owners via the InnerClasses attribute") {
     val outer = javaClass("com/example/Outer")
-    val inner = javaClass("com/example/Outer$Inner")
+    val inner = javaClass(
+      "com/example/Outer$Inner",
+      innerClass = Some(("com/example/Outer", "Inner")),
+    )
     for {
       jar  <- createJar(List(outer, inner))
       syms <- indexer.indexJar(jar)
-      innerSym = syms.find(_.name == "Inner")
-    } yield expect(innerSym.exists(_.owner.contains(IndexTestFixtures.tid("com.example.Outer"))))
+      innerSym = syms.find(_.id == SymbolId.tpe(List("com", "example"), List("Outer"), "Inner"))
+    } yield expect(innerSym.isDefined) and
+      expect(innerSym.exists(_.name == "Inner")) and
+      expect(innerSym.exists(_.owner.contains(IndexTestFixtures.tid("com.example.Outer"))))
+  }
+
+  test("a class whose simple name literally contains `$` (no InnerClasses record) is kept intact") {
+    // Without an InnerClasses entry, ASM can't tell `Foo$Bar` apart from `Outer$Inner`; the visitor must default
+    // to treating the segment as a single name so user-written `$` identifiers and Scala 3's `foo$package`
+    // top-level wrapper aren't shredded into bogus owner chains.
+    val cls = javaClass("com/example/Foo$Bar")
+    for {
+      jar  <- createJar(List(cls))
+      syms <- indexer.indexJar(jar)
+    } yield expect(
+      syms.exists(_.id == SymbolId.tpe(List("com", "example"), Nil, "Foo$Bar"))
+    ) and expect(syms.forall(_.owner.isEmpty)) // no InnerClasses → no outer
+  }
+
+  test("module-class trailing $ on a synthetic top-level wrapper stays as a single name segment") {
+    // Scala 3 lifts top-level defs into a synthetic class named `foo$package` (with module-class suffix `foo$package$`).
+    // No InnerClasses entry; previous code split on `$` and produced owners=[\"foo\",\"package\"].
+    val wrapper = javaClass(
+      "foo/foo$package$",
+      methods = List(("bar", "()I", Opcodes.ACC_PUBLIC)),
+    )
+    for {
+      jar  <- createJar(List(wrapper))
+      syms <- indexer.indexJar(jar)
+      objSym = syms.find(_.kind == SymbolKind.Object)
+      barSym = syms.find(_.name == "bar")
+    } yield expect(objSym.exists(_.id == SymbolId.term(List("foo"), Nil, "foo$package"))) and
+      expect(barSym.exists(_.id == SymbolId.term(List("foo"), List("foo$package"), "bar")))
+  }
+
+  test("anonymous classes (InnerClass record with null innerName) are skipped") {
+    val outer = javaClass("com/example/Holder")
+    val anon  = javaClass(
+      "com/example/Holder$1",
+      // ASM emits a record with innerName = null for anonymous classes.
+      innerClass = Some(("com/example/Holder", null)),
+    )
+    for {
+      jar  <- createJar(List(outer, anon))
+      syms <- indexer.indexJar(jar)
+    } yield expect(syms.exists(_.id == IndexTestFixtures.tid("com.example.Holder"))) and
+      expect(!syms.exists(_.id.render.contains("Holder$1")))
   }
 
   test("parent classes extracted") {

--- a/sls/test/src/org/scala/abusers/sls/index/IndexTypesSpec.scala
+++ b/sls/test/src/org/scala/abusers/sls/index/IndexTypesSpec.scala
@@ -33,9 +33,29 @@ object IndexTypesSpec extends SimpleIOSuite {
     IO(expect(id == SymbolId.term(List("crossproducer"), Nil, "Lib")))
   }
 
-  test("fromJvm handles inner classes") {
-    val id = SymbolId.fromJvm("com/example/Outer$Inner", memberName = None)
+  test("fromJvm decomposes nested classes via the InnerClasses attribute") {
+    val id = SymbolId.fromJvm(
+      "com/example/Outer$Inner",
+      memberName = None,
+      innerOuterName = Some("com/example/Outer"),
+      innerSimpleName = Some("Inner"),
+    )
     IO(expect(id == SymbolId.tpe(List("com", "example"), List("Outer"), "Inner")))
+  }
+
+  test("fromJvm without inner-class info keeps `$` inside the simple name (no naive split)") {
+    // No InnerClasses record ⇒ bytecode can't tell `Foo$Bar` from `Outer$Inner` apart, so keep the segment whole.
+    val id = SymbolId.fromJvm("com/example/Foo$Bar", memberName = None)
+    IO(expect(id == SymbolId.tpe(List("com", "example"), Nil, "Foo$Bar")))
+  }
+
+  test("fromJvm on the Scala 3 `foo$package` top-level wrapper preserves the synthetic name") {
+    val obj    = SymbolId.fromJvm("foo/foo$package$", memberName = None)
+    val method = SymbolId.fromJvm("foo/foo$package$", memberName = Some("bar"))
+    IO(
+      expect(obj == SymbolId.term(List("foo"), Nil, "foo$package")) &&
+        expect(method == SymbolId.term(List("foo"), List("foo$package"), "bar"))
+    )
   }
 
   test("fromSemanticDb parses a type symbol") {


### PR DESCRIPTION
## Summary
- Replace `core.split('$')` in `SymbolId.fromJvm` with ASM's `InnerClasses` attribute as the source of truth for nested-class decomposition.
- Restructure `IndexClassVisitor`: defer class-symbol emission to `visitEnd` (so `visitInnerClass` has fired), add a `skipped` flag so methods/fields of filtered/anonymous classes don't leak with an orphan owner.
- Add tests for top-level user `Foo$Bar`, the Scala 3 `foo$package$` synthetic wrapper (both module-class id and member id), nested class via `InnerClasses`, and anonymous-class (`innerName == null`) skipping.

Closes #64

## Test plan
- [x] `./mill sls.compile`
- [x] `./mill sls.test` — all suites green, including new cases
- [x] `./mill sls.fix` — clean, no unused symbols introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)