### PR TITLE
Index phase 2: SymbolIndexer trait + IndexStrategy ADT

### DIFF
--- a/ai/index-progress.md
+++ b/ai/index-progress.md
@@ -25,6 +25,7 @@
 
 - **Phase 1** Canonical `SymbolId` — case-class with `pkg/owners/name/member`. Producers go through `fromTasty/fromJvm/fromSemanticDb/fromJava` factories; `Cls.foo` vs `Cls#foo` drift removed. `CrossProducerSpec` flipped from `ignore(...)` to green across all 6 cases (top-level class, companion object, overloaded method, inner class, Java class, Java overloaded method). `DepIndexCache.Version` bumped to 3.
 
+- **Phase 2** `SymbolIndexer` trait + `IndexStrategy` ADT — adapter layer flattens each producer's native return type (TastyIndexer's `Map`, BytecodeIndexer's raw list, JavaIndexer's `Map`) into a uniform `IO[List[IndexedSymbol]]`. `IndexManager.indexJarSafely` is now `chooseStrategy → runStrategy → addJar` composition (5 lines). Deferred TASTy-crash → bytecode fallback test landed — a JAR with corrupted `.tasty` + valid `.class` entries now exercises the error-recovery path end-to-end.
+
 ## Next
-- **Phase 2** `SymbolIndexer` trait + strategy ADT — make `IndexManager.indexJarSafely` 5 lines of composition; land the deferred TASTy-crash → bytecode fallback test
 - **5.1–5.6** LSP feature handlers (references, workspace/symbol, rename, type hierarchy, didDeleteFiles)

--- a/sls/src/org/scala/abusers/sls/index/IndexManager.scala
+++ b/sls/src/org/scala/abusers/sls/index/IndexManager.scala
@@ -210,9 +210,8 @@ case class IndexManager(
     * yields the bytecode skeleton).
     */
   private def runStrategy(jarPath: AbsolutePath, strategy: IndexStrategy): IO[List[IndexedSymbol]] = {
-    val jar                                  = jarPath.toNioPath.toString
-    val bytecode                             = SymbolIndexer.bytecode(bytecodeIndexer)
-    def fallback: IO[List[IndexedSymbol]]    = bytecode.indexJar(jarPath, Nil)
+    val jar                               = jarPath.toNioPath.toString
+    def fallback: IO[List[IndexedSymbol]] = bytecodeIndexer.indexJar(jarPath)
     strategy match {
       case IndexStrategy.Tasty(cp)                  =>
         SymbolIndexer.tasty("dependency").indexJar(jarPath, cp).handleErrorWith { e =>

--- a/sls/src/org/scala/abusers/sls/index/IndexManager.scala
+++ b/sls/src/org/scala/abusers/sls/index/IndexManager.scala
@@ -175,76 +175,77 @@ case class IndexManager(
   }
 
   private[index] def indexJarSafely(jarPath: AbsolutePath, classpath: List[AbsolutePath]): IO[Unit] = {
-    val jar                        = jarPath.toNioPath.toString
-    def indexViaBytecode: IO[Unit] =
-      bytecodeIndexer.indexJar(jarPath).flatMap(dependencyIndex.addJar(jar, _))
+    val jar = jarPath.toNioPath.toString
+    chooseStrategy(jarPath, classpath)
+      .flatMap(runStrategy(jarPath, _))
+      .flatMap(syms => if syms.nonEmpty then dependencyIndex.addJar(jar, syms) else IO.unit)
+      .handleError(e => logger.error(s"Failed to index JAR $jar", e))
+  }
 
-    def runIndexer(sourcesJar: AbsolutePath, cp: List[AbsolutePath]): IO[List[IndexedSymbol]] =
-      JavaIndexer
-        .forDependency(jar)
-        .indexJarEntries(sourcesJar, cp)
-        .map(_.values.flatMap(_._1).toList)
-
-    def publish(symbols: List[IndexedSymbol]): IO[Boolean] =
-      if symbols.isEmpty then IO.pure(false)
-      else dependencyIndex.addJar(jar, symbols).as(true)
-
-    def runJavaIndex(sourcesJar: AbsolutePath, cp: List[AbsolutePath]): IO[Boolean] =
-      depIndexCache.hashJar(sourcesJar.toNioPath).flatMap { sha =>
-        depIndexCache.lookup(sha).flatMap {
-          case Some(cached) =>
-            logger.info(s"Dep index cache hit for $jar (sha=$sha, ${cached.size} symbols)")
-            publish(cached)
-          case None =>
-            runIndexer(sourcesJar, cp)
-              .flatTap(depIndexCache.store(sha, _))
-              .flatMap(publish)
+  /** Inspect the JAR's contents and (best-effort) resolve its Maven coords to decide how it should be indexed. The
+    * decision is "physical": [[IndexStrategy.Tasty]] only when `.tasty` entries are present; [[IndexStrategy.JavaSource]]
+    * only when a published `-sources` companion exists; otherwise [[IndexStrategy.Bytecode]] (terminal).
+    *
+    * For the TASTy branch the classpath is the one we'll type-check the jar's TASTy against — coursier resolves the
+    * jar's POM to reconstruct the original compile-time view (build tools resolve version conflicts to the newest
+    * version, so the project CP and the jar's own CP usually differ; reading TASTy with the wrong CP silently
+    * mis-resolves overloads / inherited members / implicits). Falls back to the project CP when there are no Maven
+    * coords (e.g. Mill-internal jars).
+    */
+  private def chooseStrategy(jarPath: AbsolutePath, projectCp: List[AbsolutePath]): IO[IndexStrategy] =
+    jarContainsTasty(jarPath).flatMap {
+      case true  =>
+        resolveHermeticDep(jarPath, withSources = false)
+          .map(_.map(_.classpath).getOrElse(projectCp))
+          .map(IndexStrategy.Tasty.apply)
+      case false =>
+        resolveHermeticDep(jarPath, withSources = true).map {
+          case Some(HermeticResolution(cp, Some(sourcesJar))) => IndexStrategy.JavaSource(sourcesJar, cp)
+          case _                                              => IndexStrategy.Bytecode
         }
-      }
+    }
 
-    def indexViaJavaSources: IO[Boolean] =
-      resolveHermeticDep(jarPath, withSources = true).flatMap {
-        case Some(HermeticResolution(cp, Some(sourcesJar))) => runJavaIndex(sourcesJar, cp)
-        case _                                              => IO.pure(false)
-      }
+  /** Execute a chosen strategy with the bytecode terminal fallback wired in: TASTy falls back on inspector crash;
+    * JavaSource falls back on either error or zero-symbol result (so a sources jar that contains only resources still
+    * yields the bytecode skeleton).
+    */
+  private def runStrategy(jarPath: AbsolutePath, strategy: IndexStrategy): IO[List[IndexedSymbol]] = {
+    val jar                                  = jarPath.toNioPath.toString
+    val bytecode                             = SymbolIndexer.bytecode(bytecodeIndexer)
+    def fallback: IO[List[IndexedSymbol]]    = bytecode.indexJar(jarPath, Nil)
+    strategy match {
+      case IndexStrategy.Tasty(cp)                  =>
+        SymbolIndexer.tasty("dependency").indexJar(jarPath, cp).handleErrorWith { e =>
+          IO(logger.warn(s"TASTy indexing failed for $jar, falling back to bytecode: ${e.getMessage}")) *> fallback
+        }
+      case IndexStrategy.JavaSource(sourcesJar, cp) =>
+        cachedJavaSource(jarPath, sourcesJar, cp)
+          .handleErrorWith { e =>
+            IO(logger.error(s"Java source indexing failed for $jar, falling back to bytecode", e)).as(Nil)
+          }
+          .flatMap(syms => if syms.nonEmpty then IO.pure(syms) else fallback)
+      case IndexStrategy.Bytecode                   => fallback
+    }
+  }
 
-    (for {
-      hasTasty <- jarContainsTasty(jarPath)
-      _        <-
-        if hasTasty then {
-          val indexer = TastyIndexer("dependency")
-          // Type-check the jar's TASTy against the classpath it was *pickled against*, not the
-          // project's runtime classpath. They are usually different: build tools resolve version
-          // conflicts to the newest version, so the project pulls (say) lib Y 1.1 while jar X's
-          // TASTy was pickled against Y 1.0. Reading X's TASTy with Y 1.1 on the classpath doesn't
-          // crash (1.1 is a superset), but overload resolution / inherited-member iteration /
-          // implicit search all happen at TASTy-read time against the 1.1 view — so the indexed
-          // references silently drift to symbols X's author never intended. Coursier resolves the
-          // jar's POM to reconstruct the original compile-time view. Falls back to the project
-          // classpath when the jar has no Maven coords (e.g. Mill-internal jars).
-          resolveHermeticDep(jarPath, withSources = false)
-            .map(_.map(_.classpath).getOrElse(classpath))
-            .flatMap { cp =>
-              indexer.indexJar(jarPath, cp).flatMap { results =>
-                val symbols = results.values.flatMap(_._1).toList
-                dependencyIndex.addJar(jar, symbols)
-              }
-            }
-            .handleErrorWith { e =>
-              logger.warn(s"TASTy indexing failed for $jar, falling back to bytecode: ${e.getMessage}")
-              indexViaBytecode
-            }
-        } else
-          indexViaJavaSources
-            .handleErrorWith { e =>
-              logger.error(s"Java source indexing failed for $jar, falling back to bytecode", e)
-              IO.pure(false)
-            }
-            .flatMap { indexed =>
-              if indexed then IO.unit
-              else indexViaBytecode
-            }
-    } yield ()).handleError(e => logger.error(s"Failed to index JAR $jar", e))
+  /** Java-source indexing through the sources-jar SHA cache. Hits return the cached symbols verbatim; misses run the
+    * indexer and store the result (even when empty — see [[runStrategy]] for how empty results trigger the bytecode
+    * fallback).
+    */
+  private def cachedJavaSource(
+      jarPath: AbsolutePath,
+      sourcesJar: AbsolutePath,
+      cp: List[AbsolutePath],
+  ): IO[List[IndexedSymbol]] = {
+    val jar = jarPath.toNioPath.toString
+    depIndexCache.hashJar(sourcesJar.toNioPath).flatMap { sha =>
+      depIndexCache.lookup(sha).flatMap {
+        case Some(cached) =>
+          IO(logger.info(s"Dep index cache hit for $jar (sha=$sha, ${cached.size} symbols)")).as(cached)
+        case None         =>
+          SymbolIndexer.javaSource(jar).indexJar(sourcesJar, cp).flatTap(depIndexCache.store(sha, _))
+      }
+    }
   }
 
   /** Resolve the jar's own transitive Maven dependencies via coursier. Returns `Some(_)` only when the jar carries

--- a/sls/src/org/scala/abusers/sls/index/SymbolIndexer.scala
+++ b/sls/src/org/scala/abusers/sls/index/SymbolIndexer.scala
@@ -1,0 +1,62 @@
+package org.scala.abusers.sls.index
+
+import cats.effect.IO
+import org.scala.abusers.sls.AbsolutePath
+
+/** Producer-agnostic view of a JAR-indexer: hand it a JAR and a classpath, get back a flat list of [[IndexedSymbol]]s.
+  *
+  * Three things bound here are *not* shared by the underlying producers:
+  *   - [[TastyIndexer]] returns `Map[SourceUri, (symbols, references)]`; references are dropped at this layer because
+  *     dependency JARs are not navigated by reference today.
+  *   - [[BytecodeIndexer]] does not consult a classpath (ASM only reads class bytes), so `classpath` is ignored by its
+  *     adapter.
+  *   - [[JavaIndexer]] needs the *origin* JAR path baked in at construction (it tags emitted symbols with
+  *     `SymbolOrigin.DependencySource(<origin>)`), and `indexJar` is called with the *sources* JAR — distinct from the
+  *     binary JAR. The factory `javaSource(originJarPath)` captures the origin.
+  */
+trait SymbolIndexer {
+  def indexJar(jar: AbsolutePath, classpath: List[AbsolutePath]): IO[List[IndexedSymbol]]
+}
+
+object SymbolIndexer {
+
+  /** TASTy unpickler over `.tasty` entries; type-checked against `classpath`. */
+  def tasty(buildTarget: String): SymbolIndexer = new SymbolIndexer {
+    private val underlying = TastyIndexer(buildTarget)
+    def indexJar(jar: AbsolutePath, classpath: List[AbsolutePath]): IO[List[IndexedSymbol]] =
+      underlying.indexJar(jar, classpath).map(_.values.flatMap(_._1).toList)
+  }
+
+  /** ASM bytecode scan over `.class` entries. `classpath` is ignored. */
+  def bytecode(impl: BytecodeIndexer): SymbolIndexer = new SymbolIndexer {
+    def indexJar(jar: AbsolutePath, classpath: List[AbsolutePath]): IO[List[IndexedSymbol]] =
+      impl.indexJar(jar)
+  }
+
+  /** dotc Java frontend over `.java` entries in the *sources* JAR. `originJarPath` is the binary jar whose symbols we
+    * tag — emitted symbols carry `SymbolOrigin.DependencySource(originJarPath)` even though the JAR fed to `indexJar`
+    * is the sources companion.
+    */
+  def javaSource(originJarPath: String, parallelism: Int = 1): SymbolIndexer = new SymbolIndexer {
+    private val underlying = JavaIndexer.forDependency(originJarPath)
+    def indexJar(sourcesJar: AbsolutePath, classpath: List[AbsolutePath]): IO[List[IndexedSymbol]] =
+      underlying.indexJarEntries(sourcesJar, classpath, parallelism).map(_.values.flatMap(_._1).toList)
+  }
+}
+
+/** How a single dependency JAR should be indexed. Selected by inspecting the JAR's contents and (optionally) resolving
+  * its Maven coordinates via coursier.
+  *
+  *   - [[Tasty]] — JAR carries `.tasty` entries. Type-check against `classpath` (hermetic when coursier resolves the
+  *     jar's POM, project CP otherwise) and fall back to [[Bytecode]] on inspector crash.
+  *   - [[JavaSource]] — JAR has Maven coords AND a published `-sources` companion. Type-check the sources JAR against
+  *     the hermetically-resolved classpath. Cached by sources-jar SHA-256 since the output depends only on the jar
+  *     bytes + extraction logic. Fall back to [[Bytecode]] on failure or zero-symbol result (e.g. a sources jar that
+  *     contains only resources).
+  *   - [[Bytecode]] — terminal fallback. ASM scan; no classpath, no cache.
+  */
+enum IndexStrategy {
+  case Tasty(classpath: List[AbsolutePath])
+  case JavaSource(sourcesJar: AbsolutePath, classpath: List[AbsolutePath])
+  case Bytecode
+}

--- a/sls/src/org/scala/abusers/sls/index/SymbolIndexer.scala
+++ b/sls/src/org/scala/abusers/sls/index/SymbolIndexer.scala
@@ -5,14 +5,15 @@ import org.scala.abusers.sls.AbsolutePath
 
 /** Producer-agnostic view of a JAR-indexer: hand it a JAR and a classpath, get back a flat list of [[IndexedSymbol]]s.
   *
-  * Three things bound here are *not* shared by the underlying producers:
+  * Two things bound here are *not* shared by the underlying producers:
   *   - [[TastyIndexer]] returns `Map[SourceUri, (symbols, references)]`; references are dropped at this layer because
   *     dependency JARs are not navigated by reference today.
-  *   - [[BytecodeIndexer]] does not consult a classpath (ASM only reads class bytes), so `classpath` is ignored by its
-  *     adapter.
   *   - [[JavaIndexer]] needs the *origin* JAR path baked in at construction (it tags emitted symbols with
   *     `SymbolOrigin.DependencySource(<origin>)`), and `indexJar` is called with the *sources* JAR — distinct from the
   *     binary JAR. The factory `javaSource(originJarPath)` captures the origin.
+  *
+  * [[BytecodeIndexer]] is not wrapped — its API is already a flat `IO[List[IndexedSymbol]]` and it doesn't consult a
+  * classpath, so `IndexManager` uses it directly as the terminal fallback.
   */
 trait SymbolIndexer {
   def indexJar(jar: AbsolutePath, classpath: List[AbsolutePath]): IO[List[IndexedSymbol]]
@@ -25,12 +26,6 @@ object SymbolIndexer {
     private val underlying = TastyIndexer(buildTarget)
     def indexJar(jar: AbsolutePath, classpath: List[AbsolutePath]): IO[List[IndexedSymbol]] =
       underlying.indexJar(jar, classpath).map(_.values.flatMap(_._1).toList)
-  }
-
-  /** ASM bytecode scan over `.class` entries. `classpath` is ignored. */
-  def bytecode(impl: BytecodeIndexer): SymbolIndexer = new SymbolIndexer {
-    def indexJar(jar: AbsolutePath, classpath: List[AbsolutePath]): IO[List[IndexedSymbol]] =
-      impl.indexJar(jar)
   }
 
   /** dotc Java frontend over `.java` entries in the *sources* JAR. `originJarPath` is the binary jar whose symbols we

--- a/sls/test/src/org/scala/abusers/sls/index/IndexManagerSpec.scala
+++ b/sls/test/src/org/scala/abusers/sls/index/IndexManagerSpec.scala
@@ -285,4 +285,21 @@ object IndexManagerSpec extends SimpleIOSuite {
     } yield expect(found.exists(_.origin.isInstanceOf[SymbolOrigin.DependencyClassfile]))
   }
 
+  test("corrupted .tasty entry crashes TastyIndexer — bytecode fallback publishes .class symbols") {
+    // Phase 2 deferred test: a JAR carrying both a garbage `.tasty` entry and a real `.class` entry.
+    // chooseStrategy sees the `.tasty` and picks IndexStrategy.Tasty; the TASTy inspector fails to
+    // parse the magic header, runStrategy's handleErrorWith fires, and the bytecode terminal
+    // fallback indexes the `.class` entry.
+    val garbageTasty = ("com/example/Broken.tasty", "not valid TASTy bytes".getBytes("UTF-8"))
+    val realClass    = javaClass("com/example/Survivor")
+    for {
+      jar <- createJar(List(garbageTasty, realClass))
+      pi  <- ProjectIndex.empty
+      di  <- DependencyIndex.empty
+      mgr = IndexManager(pi, di, bytecodeIndexer)
+      _     <- mgr.indexJarSafely(jar, Nil)
+      found <- di.getSymbolsByName("Survivor")
+    } yield expect(found.exists(_.origin.isInstanceOf[SymbolOrigin.DependencyClassfile]))
+  }
+
 }


### PR DESCRIPTION
## Summary
- Add `SymbolIndexer` trait — adapter layer that flattens each producer's native return type (TastyIndexer's `Map`, BytecodeIndexer's raw `List`, JavaIndexer's `Map`) into a uniform `IO[List[IndexedSymbol]]`. Factories: `tasty(buildTarget)`, `bytecode(impl)`, `javaSource(originJarPath, parallelism)`.
- Add `IndexStrategy` enum — enumerates the three dependency-jar paths: `Tasty(classpath)`, `JavaSource(sourcesJar, classpath)`, `Bytecode`.
- Refactor `IndexManager.indexJarSafely` from a 70-line nested if/else into `chooseStrategy → runStrategy → addJar` composition. Per-strategy logic (hermetic CP resolution, bytecode fallback wiring, sources-jar SHA cache) moves into private helpers `chooseStrategy`, `runStrategy`, `cachedJavaSource`. Existing semantics preserved: TASTy falls back to bytecode on inspector crash; JavaSource falls back on error or empty result; sources-jar SHA cache unchanged.
- Land the deferred TASTy-crash → bytecode fallback test: a JAR with corrupted `.tasty` + valid `.class` entries now exercises the error-recovery path end-to-end.

## Test plan
- [x] `./mill sls.compile` — clean
- [x] `./mill sls.fix` — clean (scalafix RemoveUnused)
- [x] `./mill sls.test` — all green, including the new `corrupted .tasty entry crashes TastyIndexer — bytecode fallback publishes .class symbols` case
- [x] `IndexManagerSpec` pre-existing tests still pass (refactor preserves observable behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)