### PR TITLE
Index phase 3: CoreState dedup for ProjectIndex/DependencyIndex

### DIFF
--- a/ai/index-progress.md
+++ b/ai/index-progress.md
@@ -27,5 +27,7 @@
 
 - **Phase 2** `SymbolIndexer` trait + `IndexStrategy` ADT — adapter layer flattens each producer's native return type (TastyIndexer's `Map`, BytecodeIndexer's raw list, JavaIndexer's `Map`) into a uniform `IO[List[IndexedSymbol]]`. `IndexManager.indexJarSafely` is now `chooseStrategy → runStrategy → addJar` composition (5 lines). Deferred TASTy-crash → bytecode fallback test landed — a JAR with corrupted `.tasty` + valid `.class` entries now exercises the error-recovery path end-to-end.
 
+- **Phase 3** `CoreState` deduplication — extracted `private[index] CoreState(symbols, nameTrie, camelCaseTrie, subtypes)` with `add(List[IndexedSymbol])` / `remove(Set[SymbolId])`. `ProjectIndex.State` wraps `core` + `byFile` + `references` + `refsByFile`; `DependencyIndex.State` wraps `core` + `jarFilters` + `symbolJar`. The `var nameTrie = ...; nameTrie = nameTrie.insert(...)` accumulators collapsed to `foldLeft` over `CoreState.add`. Wrapping state-update sites are now ~11–22 lines each (down from ~41–55). All existing specs stay green.
+
 ## Next
 - **5.1–5.6** LSP feature handlers (references, workspace/symbol, rename, type hierarchy, didDeleteFiles)

--- a/sls/src/org/scala/abusers/sls/index/CoreState.scala
+++ b/sls/src/org/scala/abusers/sls/index/CoreState.scala
@@ -1,0 +1,71 @@
+package org.scala.abusers.sls.index
+
+private[index] case class CoreState(
+    symbols: Map[SymbolId, IndexedSymbol],
+    nameTrie: PatriciaTrie[Set[SymbolId]],
+    camelCaseTrie: PatriciaTrie[Set[SymbolId]],
+    subtypes: Map[SymbolId, Set[SymbolId]],
+)
+
+private[index] object CoreState {
+
+  val empty: CoreState = CoreState(
+    symbols = Map.empty,
+    nameTrie = PatriciaTrie.empty,
+    camelCaseTrie = PatriciaTrie.empty,
+    subtypes = Map.empty,
+  )
+
+  def add(s: CoreState, syms: List[IndexedSymbol]): CoreState =
+    syms.foldLeft(s) { (acc, sym) =>
+      val lower = sym.name.toLowerCase
+      val cc    = CamelCaseUtils.extractPascalCase(sym.name)
+
+      val nameTrie      = insertId(acc.nameTrie, lower, sym.id)
+      val camelCaseTrie = if cc.isEmpty then acc.camelCaseTrie else insertId(acc.camelCaseTrie, cc, sym.id)
+      val subtypes      = sym.parents.foldLeft(acc.subtypes) { (m, parent) =>
+        m.updatedWith(parent)(_.fold(Some(Set(sym.id)))(set => Some(set + sym.id)))
+      }
+
+      acc.copy(
+        symbols = acc.symbols + (sym.id -> sym),
+        nameTrie = nameTrie,
+        camelCaseTrie = camelCaseTrie,
+        subtypes = subtypes,
+      )
+    }
+
+  def remove(s: CoreState, ids: Set[SymbolId]): CoreState =
+    ids.foldLeft(s) { (acc, id) =>
+      acc.symbols.get(id) match {
+        case None      => acc
+        case Some(sym) =>
+          val lower = sym.name.toLowerCase
+          val cc    = CamelCaseUtils.extractPascalCase(sym.name)
+
+          val nameTrie      = removeId(acc.nameTrie, lower, id)
+          val camelCaseTrie = if cc.isEmpty then acc.camelCaseTrie else removeId(acc.camelCaseTrie, cc, id)
+          val subtypes      = sym.parents.foldLeft(acc.subtypes) { (m, parent) =>
+            m.updatedWith(parent)(_.map(_ - id).filter(_.nonEmpty))
+          }
+
+          acc.copy(
+            symbols = acc.symbols - id,
+            nameTrie = nameTrie,
+            camelCaseTrie = camelCaseTrie,
+            subtypes = subtypes,
+          )
+      }
+    }
+
+  private def insertId(trie: PatriciaTrie[Set[SymbolId]], key: String, id: SymbolId): PatriciaTrie[Set[SymbolId]] =
+    trie.insert(key, trie.get(key).getOrElse(Set.empty) + id)
+
+  private def removeId(trie: PatriciaTrie[Set[SymbolId]], key: String, id: SymbolId): PatriciaTrie[Set[SymbolId]] =
+    trie.get(key) match {
+      case None      => trie
+      case Some(set) =>
+        val next = set - id
+        if next.isEmpty then trie.remove(key) else trie.insert(key, next)
+    }
+}

--- a/sls/src/org/scala/abusers/sls/index/CoreState.scala
+++ b/sls/src/org/scala/abusers/sls/index/CoreState.scala
@@ -35,6 +35,13 @@ private[index] object CoreState {
       )
     }
 
+  def updateLocations(s: CoreState, updates: Map[SymbolId, Location]): CoreState = {
+    val newSymbols = updates.foldLeft(s.symbols) { case (syms, (id, loc)) =>
+      syms.updatedWith(id)(_.map(_.copy(location = Some(loc))))
+    }
+    s.copy(symbols = newSymbols)
+  }
+
   def remove(s: CoreState, ids: Set[SymbolId]): CoreState =
     ids.foldLeft(s) { (acc, id) =>
       acc.symbols.get(id) match {

--- a/sls/src/org/scala/abusers/sls/index/DependencyIndex.scala
+++ b/sls/src/org/scala/abusers/sls/index/DependencyIndex.scala
@@ -39,12 +39,7 @@ class DependencyIndex private (state: Ref[IO, DependencyIndex.State]) {
     state.update(addJarToState(_, jarPath, symbols))
 
   def updateLocations(updates: Map[SymbolId, Location]): IO[Unit] =
-    state.update { s =>
-      val newSymbols = updates.foldLeft(s.core.symbols) { case (syms, (id, loc)) =>
-        syms.updatedWith(id)(_.map(_.copy(location = Some(loc))))
-      }
-      s.copy(core = s.core.copy(symbols = newSymbols))
-    }
+    state.update(s => s.copy(core = CoreState.updateLocations(s.core, updates)))
 
   def jarMightContain(jarPath: String, name: String): IO[Boolean] =
     state.get.map { s =>

--- a/sls/src/org/scala/abusers/sls/index/DependencyIndex.scala
+++ b/sls/src/org/scala/abusers/sls/index/DependencyIndex.scala
@@ -8,12 +8,12 @@ class DependencyIndex private (state: Ref[IO, DependencyIndex.State]) {
   import DependencyIndex.*
 
   def getSymbol(id: SymbolId): IO[Option[IndexedSymbol]] =
-    state.get.map(_.symbols.get(id))
+    state.get.map(_.core.symbols.get(id))
 
   def getSymbolsByName(name: String): IO[Set[IndexedSymbol]] =
     state.get.map { s =>
       val lower = name.toLowerCase
-      s.nameTrie.get(lower).getOrElse(Set.empty).flatMap(s.symbols.get)
+      s.core.nameTrie.get(lower).getOrElse(Set.empty).flatMap(s.core.symbols.get)
     }
 
   def searchSymbols(query: String): IO[List[IndexedSymbol]] =
@@ -21,29 +21,29 @@ class DependencyIndex private (state: Ref[IO, DependencyIndex.State]) {
       val ids =
         if CamelCaseUtils.isCamelCaseQuery(query) then {
           val ccKey = query.toLowerCase
-          s.camelCaseTrie.prefixSearch(ccKey).flatMap(_._2).toSet
+          s.core.camelCaseTrie.prefixSearch(ccKey).flatMap(_._2).toSet
         } else {
           val lower = query.toLowerCase
-          s.nameTrie.prefixSearch(lower).flatMap(_._2).toSet
+          s.core.nameTrie.prefixSearch(lower).flatMap(_._2).toSet
         }
-      ids.flatMap(s.symbols.get).toList
+      ids.flatMap(s.core.symbols.get).toList
     }
 
   def getSubtypes(id: SymbolId): IO[Set[SymbolId]] =
-    state.get.map(_.subtypes.getOrElse(id, Set.empty))
+    state.get.map(_.core.subtypes.getOrElse(id, Set.empty))
 
   def getSupertypes(id: SymbolId): IO[List[SymbolId]] =
-    state.get.map(s => s.symbols.get(id).map(_.parents).getOrElse(Nil))
+    state.get.map(s => s.core.symbols.get(id).map(_.parents).getOrElse(Nil))
 
   def addJar(jarPath: String, symbols: List[IndexedSymbol]): IO[Unit] =
     state.update(addJarToState(_, jarPath, symbols))
 
   def updateLocations(updates: Map[SymbolId, Location]): IO[Unit] =
     state.update { s =>
-      val newSymbols = updates.foldLeft(s.symbols) { case (syms, (id, loc)) =>
+      val newSymbols = updates.foldLeft(s.core.symbols) { case (syms, (id, loc)) =>
         syms.updatedWith(id)(_.map(_.copy(location = Some(loc))))
       }
-      s.copy(symbols = newSymbols)
+      s.copy(core = s.core.copy(symbols = newSymbols))
     }
 
   def jarMightContain(jarPath: String, name: String): IO[Boolean] =
@@ -51,7 +51,7 @@ class DependencyIndex private (state: Ref[IO, DependencyIndex.State]) {
       s.jarFilters.get(jarPath).exists(_.mightContain(name.toLowerCase))
     }
 
-  def symbolCount: IO[Int] = state.get.map(_.symbols.size)
+  def symbolCount: IO[Int] = state.get.map(_.core.symbols.size)
   def jarCount: IO[Int]    = state.get.map(_.jarFilters.size)
 }
 
@@ -61,62 +61,27 @@ object DependencyIndex {
     Ref[IO].of(State.empty).map(new DependencyIndex(_))
 
   private[index] case class State(
-      symbols: Map[SymbolId, IndexedSymbol],
-      nameTrie: PatriciaTrie[Set[SymbolId]],
-      camelCaseTrie: PatriciaTrie[Set[SymbolId]],
-      subtypes: Map[SymbolId, Set[SymbolId]],
+      core: CoreState,
       jarFilters: Map[String, BloomFilter],
       symbolJar: Map[SymbolId, String],
   )
 
   private[index] object State {
     val empty: State = State(
-      symbols = Map.empty,
-      nameTrie = PatriciaTrie.empty,
-      camelCaseTrie = PatriciaTrie.empty,
-      subtypes = Map.empty,
+      core = CoreState.empty,
       jarFilters = Map.empty,
       symbolJar = Map.empty,
     )
   }
 
   private def addJarToState(s: State, jarPath: String, newSymbols: List[IndexedSymbol]): State = {
-    var symbols       = s.symbols
-    var nameTrie      = s.nameTrie
-    var camelCaseTrie = s.camelCaseTrie
-    var subtypesMap   = s.subtypes
-    var symbolJar     = s.symbolJar
-    var bloom         = BloomFilter(math.max(newSymbols.size, 16), 0.01)
-
-    newSymbols.foreach { sym =>
-      symbols = symbols + (sym.id     -> sym)
-      symbolJar = symbolJar + (sym.id -> jarPath)
-
-      val lower = sym.name.toLowerCase
-      bloom = bloom.add(lower)
-
-      val nameSet = nameTrie.get(lower).getOrElse(Set.empty)
-      nameTrie = nameTrie.insert(lower, nameSet + sym.id)
-
-      val cc = CamelCaseUtils.extractPascalCase(sym.name)
-      if cc.nonEmpty then {
-        val ccSet = camelCaseTrie.get(cc).getOrElse(Set.empty)
-        camelCaseTrie = camelCaseTrie.insert(cc, ccSet + sym.id)
-      }
-
-      sym.parents.foreach { parent =>
-        subtypesMap = subtypesMap.updatedWith(parent) {
-          case Some(set) => Some(set + sym.id)
-          case None      => Some(Set(sym.id))
-        }
-      }
+    val bloom = newSymbols.foldLeft(BloomFilter(math.max(newSymbols.size, 16), 0.01)) { (b, sym) =>
+      b.add(sym.name.toLowerCase)
     }
+    val symbolJar = newSymbols.foldLeft(s.symbolJar)((m, sym) => m + (sym.id -> jarPath))
 
     s.copy(
-      symbols = symbols,
-      nameTrie = nameTrie,
-      camelCaseTrie = camelCaseTrie,
-      subtypes = subtypesMap,
+      core = CoreState.add(s.core, newSymbols),
       jarFilters = s.jarFilters + (jarPath -> bloom),
       symbolJar = symbolJar,
     )

--- a/sls/src/org/scala/abusers/sls/index/ProjectIndex.scala
+++ b/sls/src/org/scala/abusers/sls/index/ProjectIndex.scala
@@ -9,12 +9,12 @@ class ProjectIndex private (state: Ref[IO, ProjectIndex.State]) {
   import ProjectIndex.*
 
   def getSymbol(id: SymbolId): IO[Option[IndexedSymbol]] =
-    state.get.map(_.symbols.get(id))
+    state.get.map(_.core.symbols.get(id))
 
   def getSymbolsByName(name: String): IO[Set[IndexedSymbol]] =
     state.get.map { s =>
       val lower = name.toLowerCase
-      s.nameTrie.get(lower).getOrElse(Set.empty).flatMap(s.symbols.get)
+      s.core.nameTrie.get(lower).getOrElse(Set.empty).flatMap(s.core.symbols.get)
     }
 
   def searchSymbols(query: String): IO[List[IndexedSymbol]] =
@@ -22,17 +22,17 @@ class ProjectIndex private (state: Ref[IO, ProjectIndex.State]) {
       val ids =
         if CamelCaseUtils.isCamelCaseQuery(query) then {
           val ccKey = query.toLowerCase
-          s.camelCaseTrie.prefixSearch(ccKey).flatMap(_._2).toSet
+          s.core.camelCaseTrie.prefixSearch(ccKey).flatMap(_._2).toSet
         } else {
           val lower = query.toLowerCase
-          s.nameTrie.prefixSearch(lower).flatMap(_._2).toSet
+          s.core.nameTrie.prefixSearch(lower).flatMap(_._2).toSet
         }
-      ids.flatMap(s.symbols.get).toList
+      ids.flatMap(s.core.symbols.get).toList
     }
 
   def getSymbolsInFile(uri: SourceUri): IO[Set[IndexedSymbol]] =
     state.get.map { s =>
-      s.byFile.getOrElse(uri, Set.empty).flatMap(s.symbols.get)
+      s.byFile.getOrElse(uri, Set.empty).flatMap(s.core.symbols.get)
     }
 
   def getReferences(id: SymbolId): IO[List[SymbolReference]] =
@@ -42,22 +42,22 @@ class ProjectIndex private (state: Ref[IO, ProjectIndex.State]) {
     state.get.map(_.refsByFile.getOrElse(uri, Nil))
 
   def getSubtypes(id: SymbolId): IO[Set[SymbolId]] =
-    state.get.map(_.subtypes.getOrElse(id, Set.empty))
+    state.get.map(_.core.subtypes.getOrElse(id, Set.empty))
 
   def getSupertypes(id: SymbolId): IO[List[SymbolId]] =
-    state.get.map(s => s.symbols.get(id).map(_.parents).getOrElse(Nil))
+    state.get.map(s => s.core.symbols.get(id).map(_.parents).getOrElse(Nil))
 
   def updateFiles(files: Map[SourceUri, (List[IndexedSymbol], List[SymbolReference])]): IO[Unit] =
     state.update { s =>
       val totalRefs = files.values.map(_._2.size).sum
       logger.info(
-        s"updateFiles: ${files.size} files, ${files.values.map(_._1.size).sum} symbols, $totalRefs refs. Before: ${s.references.size} ref keys, ${s.symbols.size} symbols"
+        s"updateFiles: ${files.size} files, ${files.values.map(_._1.size).sum} symbols, $totalRefs refs. Before: ${s.references.size} ref keys, ${s.core.symbols.size} symbols"
       )
       val result = files.foldLeft(s) { case (state, (uri, (symbols, refs))) =>
         val cleaned = removeFileFromState(state, uri)
         addFileToState(cleaned, uri, symbols, refs)
       }
-      logger.info(s"updateFiles done. After: ${result.references.size} ref keys, ${result.symbols.size} symbols")
+      logger.info(s"updateFiles done. After: ${result.references.size} ref keys, ${result.core.symbols.size} symbols")
       result
     }
 
@@ -66,12 +66,12 @@ class ProjectIndex private (state: Ref[IO, ProjectIndex.State]) {
   def removeFiles(uris: Set[SourceUri]): IO[Unit] =
     state.update { s =>
       logger.info(
-        s"removeFiles called with ${uris.size} URIs, current refs=${s.references.size} keys, symbols=${s.symbols.size}"
+        s"removeFiles called with ${uris.size} URIs, current refs=${s.references.size} keys, symbols=${s.core.symbols.size}"
       )
       uris.foldLeft(s)(removeFileFromState)
     }
 
-  def symbolCount: IO[Int]                   = state.get.map(_.symbols.size)
+  def symbolCount: IO[Int]                   = state.get.map(_.core.symbols.size)
   def fileCount: IO[Int]                     = state.get.map(_.byFile.size)
   def debugReferenceKeys: IO[List[SymbolId]] = state.get.map(_.references.keys.toList)
 }
@@ -83,24 +83,18 @@ object ProjectIndex {
     Ref[IO].of(State.empty).map(new ProjectIndex(_))
 
   private[index] case class State(
-      symbols: Map[SymbolId, IndexedSymbol],
-      nameTrie: PatriciaTrie[Set[SymbolId]],
-      camelCaseTrie: PatriciaTrie[Set[SymbolId]],
+      core: CoreState,
       byFile: Map[SourceUri, Set[SymbolId]],
       references: Map[SymbolId, List[SymbolReference]],
       refsByFile: Map[SourceUri, List[SymbolReference]],
-      subtypes: Map[SymbolId, Set[SymbolId]],
   )
 
   private[index] object State {
     val empty: State = State(
-      symbols = Map.empty,
-      nameTrie = PatriciaTrie.empty,
-      camelCaseTrie = PatriciaTrie.empty,
+      core = CoreState.empty,
       byFile = Map.empty,
       references = Map.empty,
       refsByFile = Map.empty,
-      subtypes = Map.empty,
     )
   }
 
@@ -108,47 +102,21 @@ object ProjectIndex {
     val oldIds = s.byFile.getOrElse(uri, Set.empty)
     if oldIds.isEmpty && !s.refsByFile.contains(uri) then return s
 
-    var symbols       = s.symbols
-    var nameTrie      = s.nameTrie
-    var camelCaseTrie = s.camelCaseTrie
-    var subtypesMap   = s.subtypes
-
-    oldIds.foreach { id =>
-      s.symbols.get(id).foreach { sym =>
-        symbols = symbols - id
-
-        val lower = sym.name.toLowerCase
-        nameTrie = nameTrie.update(lower, _ - id)
-
-        val cc = CamelCaseUtils.extractPascalCase(sym.name)
-        if cc.nonEmpty then camelCaseTrie = camelCaseTrie.update(cc, _ - id)
-
-        sym.parents.foreach { parent =>
-          subtypesMap = subtypesMap.updatedWith(parent)(_.map(_ - id).filter(_.nonEmpty))
-        }
-      }
-    }
-
-    // Remove references for this file
     val oldRefs = s.refsByFile.getOrElse(uri, Nil)
-    var refsMap = s.references
-    oldRefs.foreach { ref =>
-      refsMap = refsMap.updatedWith(ref.symbol) {
+    val refsMap = oldRefs.foldLeft(s.references) { (m, ref) =>
+      m.updatedWith(ref.symbol) {
         case Some(list) =>
-          val filtered = list.filterNot(r => r.location.uri == uri)
+          val filtered = list.filterNot(_.location.uri == uri)
           if filtered.isEmpty then None else Some(filtered)
         case None => None
       }
     }
 
     s.copy(
-      symbols = symbols,
-      nameTrie = nameTrie,
-      camelCaseTrie = camelCaseTrie,
+      core = CoreState.remove(s.core, oldIds),
       byFile = s.byFile - uri,
       references = refsMap,
       refsByFile = s.refsByFile - uri,
-      subtypes = subtypesMap,
     )
   }
 
@@ -158,53 +126,18 @@ object ProjectIndex {
       newSymbols: List[IndexedSymbol],
       newRefs: List[SymbolReference],
   ): State = {
-    var symbols       = s.symbols
-    var nameTrie      = s.nameTrie
-    var camelCaseTrie = s.camelCaseTrie
-    var subtypesMap   = s.subtypes
-    val ids           = Set.newBuilder[SymbolId]
-
-    newSymbols.foreach { sym =>
-      symbols = symbols + (sym.id -> sym)
-      ids += sym.id
-
-      val lower   = sym.name.toLowerCase
-      val nameSet = nameTrie.get(lower).getOrElse(Set.empty)
-      nameTrie = nameTrie.insert(lower, nameSet + sym.id)
-
-      val cc = CamelCaseUtils.extractPascalCase(sym.name)
-      if cc.nonEmpty then {
-        val ccSet = camelCaseTrie.get(cc).getOrElse(Set.empty)
-        camelCaseTrie = camelCaseTrie.insert(cc, ccSet + sym.id)
-      }
-
-      sym.parents.foreach { parent =>
-        subtypesMap = subtypesMap.updatedWith(parent) {
-          case Some(set) => Some(set + sym.id)
-          case None      => Some(Set(sym.id))
-        }
-      }
-    }
-
-    var refsMap = s.references
-    newRefs.foreach { ref =>
+    val refsMap = newRefs.foldLeft(s.references) { (m, ref) =>
       logger.info(
         s"  addRef: ${ref.symbol.render} -> ${ref.location.uri}:${ref.location.startLine}:${ref.location.startCol} (${ref.referenceKind})"
       )
-      refsMap = refsMap.updatedWith(ref.symbol) {
-        case Some(list) => Some(ref :: list)
-        case None       => Some(List(ref))
-      }
+      m.updatedWith(ref.symbol)(_.fold(Some(List(ref)))(list => Some(ref :: list)))
     }
 
     s.copy(
-      symbols = symbols,
-      nameTrie = nameTrie,
-      camelCaseTrie = camelCaseTrie,
-      byFile = s.byFile + (uri -> ids.result()),
+      core = CoreState.add(s.core, newSymbols),
+      byFile = s.byFile + (uri -> newSymbols.map(_.id).toSet),
       references = refsMap,
       refsByFile = s.refsByFile + (uri -> newRefs),
-      subtypes = subtypesMap,
     )
   }
 }


### PR DESCRIPTION
## Summary
- Extract `private[index] CoreState(symbols, nameTrie, camelCaseTrie, subtypes)` with pure `add(List[IndexedSymbol])` / `remove(Set[SymbolId])` helpers — the trie/subtypes scaffolding now lives in one place.
- `ProjectIndex.State` wraps `core + byFile + references + refsByFile`; `DependencyIndex.State` wraps `core + jarFilters + symbolJar`. Bloom filters stay on `DependencyIndex` per the architecture plan.
- The `var nameTrie = ...; nameTrie = nameTrie.insert(...)` accumulator loops collapse to `foldLeft` over `CoreState.add` / `CoreState.remove`. Wrapping state-update sites are now ~11–22 lines each (down from ~41–55).

Implements Phase 3 of `ai/architecture-improvements.md`.

## Test plan
- [x] `./mill sls.compile` — clean
- [x] `./mill sls.test` — 598/598 SUCCESS (including ProjectIndexSpec, DependencyIndexSpec, CrossProducerSpec, IndexManagerSpec, the reference-set / round-trip determinism specs)
- [x] `./mill sls.fix --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)