### PR TITLE
Fix NoSuchFileException in AbsolutePath.deleteRecursively

### DIFF
--- a/sls/src/org/scala/abusers/sls/paths.scala
+++ b/sls/src/org/scala/abusers/sls/paths.scala
@@ -31,10 +31,11 @@ object AbsolutePath {
     def toFile: java.io.File                 = ap.toFile
     def exists: Boolean                      = java.nio.file.Files.exists(ap)
     def deleteRecursively: Unit              =
-      java.nio.file.Files
-        .walk(ap)
-        .sorted(java.util.Comparator.reverseOrder())
-        .forEach(java.nio.file.Files.deleteIfExists(_))
+      if java.nio.file.Files.exists(ap) then
+        java.nio.file.Files
+          .walk(ap)
+          .sorted(java.util.Comparator.reverseOrder())
+          .forEach(java.nio.file.Files.deleteIfExists(_))
   }
 }
 


### PR DESCRIPTION
## Problem

`AbsolutePath.deleteRecursively` called `Files.walk(ap)` unconditionally. When the target directory doesn't exist, `Files.walk` throws `NoSuchFileException` rather than no-opping. This surfaced on `didSave` (`ServerImpl.handleDidSave`), where `targetInfo.classesDir.deleteRecursively` runs before the classes dir has been populated:

```
java.nio.file.NoSuchFileException: .../.sls/classes/sls
  at ...Files.walk(...)
  at AbsolutePath$.deleteRecursively(paths.scala:35)
  at ServerImpl.$anonfun$4$$anonfun$1(ServerImpl.scala:267)
```

## Fix

Guard the walk on existence. This matches the `rm -rf` semantics already implied by the internal `deleteIfExists`, and makes all three callers (`ServerImpl` x2, `TastyIndexer`) safe against missing paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)