### PR TITLE
Index observability: otel spans, TASTy diagnostics, client error surfacing

### DIFF
--- a/sls/src/org/scala/abusers/sls/LoggingUtils.scala
+++ b/sls/src/org/scala/abusers/sls/LoggingUtils.scala
@@ -12,5 +12,8 @@ object LoggingUtils {
 
     def logDebug(msg: String): IO[Unit] =
       client.windowLogMessage(lsp.LogMessageParams(lsp.MessageType.LOG, msg))
+
+    def logError(msg: String): IO[Unit] =
+      client.windowLogMessage(lsp.LogMessageParams(lsp.MessageType.ERROR, msg))
   }
 }

--- a/sls/src/org/scala/abusers/sls/ServerImpl.scala
+++ b/sls/src/org/scala/abusers/sls/ServerImpl.scala
@@ -94,6 +94,7 @@ class ServerImpl(
   }
 
   def initialized(params: lsp.InitializedParams): IO[Unit] =
+
     computationQueue.synchronously {
       for {
         _       <- bspStateManager.importBuild
@@ -102,41 +103,57 @@ class ServerImpl(
       } yield ()
     }
 
+  /** Trace an LSP op and, on failure, push the full stacktrace to the client's Output channel (`window/logMessage`,
+    * Error) so it's visible in the editor without opening the trace backend — the popup the client shows only carries
+    * `getMessage`. The span already records the exception; this re-raises, so the JSON-RPC error response is still
+    * returned.
+    */
+  private def op[A](name: String)(fa: IO[A]): IO[A] =
+    Tracer[IO].span(name).profilingSurround(fa).onError { case e =>
+      lspClient.logError(s"$name failed: ${e.getMessage}\n${stackTraceOf(e)}").attempt.void
+    }
+
+  private def stackTraceOf(e: Throwable): String = {
+    val sw = new java.io.StringWriter
+    e.printStackTrace(new java.io.PrintWriter(sw))
+    sw.toString
+  }
+
   def textDocumentCompletionOp(params: lsp.CompletionParams): IO[lsp.TextDocumentCompletionOpOutput] =
     computationQueue.synchronously {
-      Tracer[IO].span("completion").profilingSurround(handleCompletion(params))
+      op("completion")(handleCompletion(params))
     }
   def textDocumentDefinitionOp(params: lsp.DefinitionParams): IO[lsp.TextDocumentDefinitionOpOutput] =
     computationQueue.synchronously {
-      Tracer[IO].span("go-to-defintion").profilingSurround(handleDefinition(params))
+      op("go-to-defintion")(handleDefinition(params))
     }
   def textDocumentDidChange(params: lsp.DidChangeTextDocumentParams): IO[Unit] =
     computationQueue.synchronously {
-      Tracer[IO].span("did-change").profilingSurround(handleDidChange(params))
+      op("did-change")(handleDidChange(params))
     }
   def textDocumentDidClose(params: lsp.DidCloseTextDocumentParams): IO[Unit] =
     computationQueue.synchronously {
-      Tracer[IO].span("did-close").profilingSurround(handleDidClose(params))
+      op("did-close")(handleDidClose(params))
     }
   def textDocumentDidOpen(params: lsp.DidOpenTextDocumentParams): IO[Unit] =
     computationQueue.synchronously {
-      Tracer[IO].span("did-open").profilingSurround(handleDidOpen(params))
+      op("did-open")(handleDidOpen(params))
     }
   def textDocumentDidSave(params: lsp.DidSaveTextDocumentParams): IO[Unit] =
     computationQueue.synchronously {
-      Tracer[IO].span("did-save").profilingSurround(handleDidSave(params))
+      op("did-save")(handleDidSave(params))
     }
   def textDocumentHoverOp(params: lsp.HoverParams): IO[lsp.TextDocumentHoverOpOutput] =
     computationQueue.synchronously {
-      Tracer[IO].span("hover").profilingSurround(handleHover(params))
+      op("hover")(handleHover(params))
     }
   def textDocumentInlayHintOp(params: lsp.InlayHintParams): IO[lsp.TextDocumentInlayHintOpOutput] =
     computationQueue.synchronously {
-      Tracer[IO].span("inlay-hints").profilingSurround(handleInlayHints(params))
+      op("inlay-hints")(handleInlayHints(params))
     }
   def textDocumentSignatureHelpOp(params: lsp.SignatureHelpParams): IO[lsp.TextDocumentSignatureHelpOpOutput] =
     computationQueue.synchronously {
-      Tracer[IO].span("signature-help").profilingSurround(handleSignatureHelp(params))
+      op("signature-help")(handleSignatureHelp(params))
     }
 
   def toPC(completionTriggerKind: Option[lsp.CompletionTriggerKind]): lsp4j.CompletionTriggerKind =
@@ -361,7 +378,7 @@ class ServerImpl(
 
   def textDocumentReferencesOp(params: lsp.ReferenceParams): IO[lsp.TextDocumentReferencesOpOutput] =
     computationQueue.synchronously {
-      handleReferences(params)
+      op("references")(handleReferences(params))
     }
 
   private def handleReferences(
@@ -438,10 +455,11 @@ class ServerImpl(
   def typeHierarchySubtypesOp(params: lsp.TypeHierarchySubtypesParams): IO[lsp.TypeHierarchySubtypesOpOutput] =
     IO.pure(lsp.TypeHierarchySubtypesOpOutput(None))
 
-  def workspaceDidDeleteFiles(params: lsp.DeleteFilesParams): IO[Unit] = {
-    val uris = params.files.map(f => SourceUri(f.uri)).toSet
-    indexManager.onFilesDeleted(uris)
-  }
+  def workspaceDidDeleteFiles(params: lsp.DeleteFilesParams): IO[Unit] =
+    op("did-delete-files") {
+      val uris = params.files.map(f => SourceUri(f.uri)).toSet
+      indexManager.onFilesDeleted(uris)
+    }
 
   def slsDebugIndexOp(params: Option[SlsDebugIndexParams]): IO[SlsDebugIndexOpOutput] = {
     val query = params.flatMap(_.query).filter(_.nonEmpty)

--- a/sls/src/org/scala/abusers/sls/index/IndexManager.scala
+++ b/sls/src/org/scala/abusers/sls/index/IndexManager.scala
@@ -16,6 +16,9 @@ import org.scala.abusers.sls.ScalaBuildTargetInformation
 import org.scala.abusers.sls.ScalaBuildTargetInformation.*
 import org.scala.abusers.sls.SourceUri
 import org.slf4j.LoggerFactory
+import org.typelevel.otel4s.trace.StatusCode
+import org.typelevel.otel4s.trace.Tracer
+import org.typelevel.otel4s.Attribute
 
 import java.io.FileInputStream
 import java.util.zip.ZipInputStream
@@ -28,7 +31,7 @@ case class IndexManager(
     depIndexCache: DepIndexCache,
     coursierCache: Cache,
     notifyProgress: String => IO[Unit] = _ => IO.unit,
-) {
+)(using Tracer[IO]) {
   private val logger          = LoggerFactory.getLogger(this.getClass)
   private val projectIndex    = symbolIndex.project
   private val dependencyIndex = symbolIndex.dependency
@@ -36,37 +39,41 @@ case class IndexManager(
   def updateOpenFile(uri: SourceUri, symbols: List[IndexedSymbol], refs: List[SymbolReference]): IO[Unit] =
     projectIndex.updateFiles(Map(uri -> (symbols, refs)))
 
-  /** Kick off the initial index population in the background. Atomically flips Cold → Bootstrapping; if the
-    * lifecycle is past Cold the call is a no-op (idempotent). On success flips Bootstrapping → Ready; on error
-    * flips Bootstrapping → Failed so [[IndexLifecycle.awaitReady]] short-circuits instead of waiting on a fiber
-    * that will never complete. Spawns under [[supervisor]] so shutdown cancels the work cleanly. Returns once
-    * the fiber is registered — callers do not block on indexing.
+  /** Kick off the initial index population in the background. Atomically flips Cold → Bootstrapping; if the lifecycle
+    * is past Cold the call is a no-op (idempotent). On success flips Bootstrapping → Ready; on error flips
+    * Bootstrapping → Failed so [[IndexLifecycle.awaitReady]] short-circuits instead of waiting on a fiber that will
+    * never complete. Spawns under [[supervisor]] so shutdown cancels the work cleanly. Returns once the fiber is
+    * registered — callers do not block on indexing.
     *
-    * The [[notifyProgress]] callback fires at start and end with a human-readable summary so the LSP client can
-    * surface progress to the user (`window/logMessage` in the wiring layer).
+    * The [[notifyProgress]] callback fires at start and end with a human-readable summary so the LSP client can surface
+    * progress to the user (`window/logMessage` in the wiring layer).
     */
   def bootstrap(targets: Set[ScalaBuildTargetInformation]): IO[Unit] = {
-    val work = for {
-      start <- IO.monotonic
-      _     <- IO(logger.info(s"Index bootstrap starting (targets=${targets.size})"))
-      _     <- notifyProgress(s"Indexing ${targets.size} targets…")
-      _     <- List(
-        indexJdkSources(),
-        indexDependencies(targets),
-        indexExistingProjectArtifacts(targets),
-      ).parSequence_
-      end       <- IO.monotonic
-      projCount <- symbolIndex.projectSymbolCount
-      depCount  <- symbolIndex.dependencySymbolCount
-      files     <- symbolIndex.fileCount
-      jars      <- symbolIndex.jarCount
-      elapsedMs = (end - start).toMillis
-      summary   =
-        s"Index bootstrap complete in ${elapsedMs}ms (projectSymbols=$projCount, dependencySymbols=$depCount, files=$files, jars=$jars)"
-      _ <- IO(logger.info(summary))
-      _ <- notifyProgress(s"Indexed $files files and $jars jars in ${elapsedMs}ms")
-      _ <- lifecycle.transition(IndexPhase.Ready)
-    } yield ()
+    // Root span of the index trace. Per-library `index.jar` spans nest under it via fiber-local context propagation
+    // (the parEvalMap fibers inherit this scope), so the trace reads as a tree: bootstrap → each library.
+    val work = Tracer[IO].span("index.bootstrap", Attribute("index.targets", targets.size.toLong)).surround {
+      for {
+        start <- IO.monotonic
+        _     <- IO(logger.info(s"Index bootstrap starting (targets=${targets.size})"))
+        _     <- notifyProgress(s"Indexing ${targets.size} targets…")
+        _     <- List(
+          indexJdkSources(),
+          indexDependencies(targets),
+          indexExistingProjectArtifacts(targets),
+        ).parSequence_
+        end       <- IO.monotonic
+        projCount <- symbolIndex.projectSymbolCount
+        depCount  <- symbolIndex.dependencySymbolCount
+        files     <- symbolIndex.fileCount
+        jars      <- symbolIndex.jarCount
+        elapsedMs = (end - start).toMillis
+        summary   =
+          s"Index bootstrap complete in ${elapsedMs}ms (projectSymbols=$projCount, dependencySymbols=$depCount, files=$files, jars=$jars)"
+        _ <- IO(logger.info(summary))
+        _ <- notifyProgress(s"Indexed $files files and $jars jars in ${elapsedMs}ms")
+        _ <- lifecycle.transition(IndexPhase.Ready)
+      } yield ()
+    }
 
     val supervised = work.handleErrorWith { e =>
       IO(logger.error("Index bootstrap failed", e)) *>
@@ -177,8 +184,9 @@ case class IndexManager(
         IO(logger.error(s"$format indexing failed for ${target.displayName}", e))
           .as(Map.empty[SourceUri, (List[IndexedSymbol], List[SymbolReference])])
       }
-      relevant = if changedSourceUris.nonEmpty then results.filter { case (uri, _) => changedSourceUris.contains(uri) }
-                 else results
+      relevant =
+        if changedSourceUris.nonEmpty then results.filter { case (uri, _) => changedSourceUris.contains(uri) }
+        else results
       _ <- IO(
         logger.info(
           s"$format index: ${relevant.size} files (of ${results.size}), ${relevant.values.map(_._1.size).sum} symbols, ${relevant.values.map(_._2.size).sum} references"
@@ -211,16 +219,30 @@ case class IndexManager(
   }
 
   private[index] def indexJarSafely(jarPath: AbsolutePath, classpath: List[AbsolutePath]): IO[Unit] = {
-    val jar = jarPath.toNioPath.toString
-    chooseStrategy(jarPath, classpath)
-      .flatMap(runStrategy(jarPath, _))
-      .flatMap(syms => if syms.nonEmpty then dependencyIndex.addJar(jar, syms) else IO.unit)
-      .handleError(e => logger.error(s"Failed to index JAR $jar", e))
+    val jar  = jarPath.toNioPath.toString
+    val name = jarPath.toNioPath.getFileName.toString
+    // One span per library, named after the jar so the trace tree is scannable. The failure is still swallowed (a bad
+    // jar degrades that library, it doesn't fail the bootstrap) but it's recorded on the span — set to Error status
+    // with the exception attached — so the failed library stands out in the trace instead of vanishing into a log line.
+    Tracer[IO].span(s"index.jar $name", Attribute("index.jar", jar)).use { span =>
+      chooseStrategy(jarPath, classpath)
+        .flatMap(runStrategy(jarPath, _))
+        .flatMap(syms =>
+          span.addAttribute(Attribute("index.symbols", syms.size.toLong)) *>
+            (if syms.nonEmpty then dependencyIndex.addJar(jar, syms) else IO.unit)
+        )
+        .handleErrorWith(e =>
+          span.recordException(e) *>
+            span.setStatus(StatusCode.Error, Option(e.getMessage).getOrElse(e.toString)) *>
+            IO(logger.error(s"Failed to index JAR $jar", e))
+        )
+    }
   }
 
   /** Inspect the JAR's contents and (best-effort) resolve its Maven coords to decide how it should be indexed. The
-    * decision is "physical": [[IndexStrategy.Tasty]] only when `.tasty` entries are present; [[IndexStrategy.JavaSource]]
-    * only when a published `-sources` companion exists; otherwise [[IndexStrategy.Bytecode]] (terminal).
+    * decision is "physical": [[IndexStrategy.Tasty]] only when `.tasty` entries are present;
+    * [[IndexStrategy.JavaSource]] only when a published `-sources` companion exists; otherwise
+    * [[IndexStrategy.Bytecode]] (terminal).
     *
     * For the TASTy branch the classpath is the one we'll type-check the jar's TASTy against — coursier resolves the
     * jar's POM to reconstruct the original compile-time view (build tools resolve version conflicts to the newest
@@ -230,7 +252,7 @@ case class IndexManager(
     */
   private def chooseStrategy(jarPath: AbsolutePath, projectCp: List[AbsolutePath]): IO[IndexStrategy] =
     jarContainsTasty(jarPath).flatMap {
-      case true  =>
+      case true =>
         resolveHermeticDep(jarPath, withSources = false)
           .map(_.map(_.classpath).getOrElse(projectCp))
           .map(IndexStrategy.Tasty.apply)
@@ -249,7 +271,7 @@ case class IndexManager(
     val jar                               = jarPath.toNioPath.toString
     def fallback: IO[List[IndexedSymbol]] = bytecodeIndexer.indexJar(jarPath)
     strategy match {
-      case IndexStrategy.Tasty(cp)                  =>
+      case IndexStrategy.Tasty(cp) =>
         SymbolIndexer.tasty("dependency").indexJar(jarPath, cp).handleErrorWith { e =>
           IO(logger.warn(s"TASTy indexing failed for $jar, falling back to bytecode: ${e.getMessage}")) *> fallback
         }
@@ -259,7 +281,7 @@ case class IndexManager(
             IO(logger.error(s"Java source indexing failed for $jar, falling back to bytecode", e)).as(Nil)
           }
           .flatMap(syms => if syms.nonEmpty then IO.pure(syms) else fallback)
-      case IndexStrategy.Bytecode                   => fallback
+      case IndexStrategy.Bytecode => fallback
     }
   }
 
@@ -277,7 +299,7 @@ case class IndexManager(
       depIndexCache.lookup(sha).flatMap {
         case Some(cached) =>
           IO(logger.info(s"Dep index cache hit for $jar (sha=$sha, ${cached.size} symbols)")).as(cached)
-        case None         =>
+        case None =>
           SymbolIndexer.javaSource(jar).indexJar(sourcesJar, cp).flatTap(depIndexCache.store(sha, _))
       }
     }

--- a/sls/src/org/scala/abusers/sls/index/JavaFrontendDriver.scala
+++ b/sls/src/org/scala/abusers/sls/index/JavaFrontendDriver.scala
@@ -3,6 +3,7 @@ package org.scala.abusers.sls.index
 import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.core.Phases.Phase
 import dotty.tools.dotc.parsing.Parser
+import dotty.tools.dotc.reporting.StoreReporter
 import dotty.tools.dotc.typer.TyperPhase
 import dotty.tools.dotc.util.ClasspathFromClassloader
 import dotty.tools.dotc.util.SourceFile
@@ -70,14 +71,19 @@ object JavaFrontendDriver {
         setup(args, initCtx) match {
           case None           => true
           case Some((_, ctx)) =>
-            given Context = ctx
+            // Swap in a StoreReporter so dotc diagnostics from outline-typing dependency/JDK Java sources (unresolved
+            // annotations like org.jspecify, JDK src.zip quirks, etc.) are buffered instead of printed. The default
+            // ConsoleReporter echoes to System.out — which here is the LSP JSON-RPC pipe, so its output corrupts the
+            // framing and crashes the client — and to System.err, which clutters the client log. CapturePhase still
+            // runs and harvests symbols regardless of these errors.
+            given Context = ctx.fresh.setReporter(new StoreReporter(null, fromTyperState = false))
             try {
               val run = newCompiler.newRun
               run.compileSources(srcs)
             } catch {
               case _: InterruptedException => ()
             }
-            !ctx.reporter.hasErrors
+            !summon[Context].reporter.hasErrors
         }
     }
 

--- a/sls/src/org/scala/abusers/sls/index/SymbolIndexer.scala
+++ b/sls/src/org/scala/abusers/sls/index/SymbolIndexer.scala
@@ -2,6 +2,7 @@ package org.scala.abusers.sls.index
 
 import cats.effect.IO
 import org.scala.abusers.sls.AbsolutePath
+import org.typelevel.otel4s.trace.Tracer
 
 /** Producer-agnostic view of a JAR-indexer: hand it a JAR and a classpath, get back a flat list of [[IndexedSymbol]]s.
   *
@@ -22,8 +23,8 @@ trait SymbolIndexer {
 object SymbolIndexer {
 
   /** TASTy unpickler over `.tasty` entries; type-checked against `classpath`. */
-  def tasty(buildTarget: String): SymbolIndexer = new SymbolIndexer {
-    private val underlying = TastyIndexer(buildTarget)
+  def tasty(buildTarget: String)(using Tracer[IO]): SymbolIndexer = new SymbolIndexer {
+    private val underlying                                                                  = TastyIndexer(buildTarget)
     def indexJar(jar: AbsolutePath, classpath: List[AbsolutePath]): IO[List[IndexedSymbol]] =
       underlying.indexJar(jar, classpath).map(_.values.flatMap(_._1).toList)
   }

--- a/sls/src/org/scala/abusers/sls/index/TastyIndexer.scala
+++ b/sls/src/org/scala/abusers/sls/index/TastyIndexer.scala
@@ -2,10 +2,14 @@ package org.scala.abusers.sls.index
 
 import cats.effect.IO
 import cats.effect.Resource
+import cats.syntax.all.*
 import org.scala.abusers.sls.toSourceUri
 import org.scala.abusers.sls.AbsolutePath
 import org.scala.abusers.sls.SourceUri
 import org.slf4j.LoggerFactory
+import org.typelevel.otel4s.trace.StatusCode
+import org.typelevel.otel4s.trace.Tracer
+import org.typelevel.otel4s.Attribute
 
 import java.io.OutputStream
 import java.io.PrintStream
@@ -16,19 +20,42 @@ private inline def safe[A](inline op: => A): Option[A] =
   try Some(op)
   catch { case NonFatal(_) => None }
 
-class TastyIndexer(buildTarget: String) {
+class TastyIndexer(buildTarget: String)(using Tracer[IO]) {
   private val logger = LoggerFactory.getLogger(this.getClass)
+
+  type Indexed = Map[SourceUri, (List[IndexedSymbol], List[SymbolReference])]
+
+  /** Record the diagnostics from a TASTy read onto the current span (the per-library `index.jar` span when called from
+    * the index bootstrap): error/warning counts, the first few messages as span events, and an Error status when any
+    * error was seen — so a jar that indexed only *partially* (e.g. classpath mismatch) stands out instead of looking
+    * like a clean success. Also logged, so the signal survives even with no trace backend attached.
+    */
+  private def attachDiagnostics(diags: List[IndexDiagnostic]): IO[Unit] =
+    IO.whenA(diags.nonEmpty) {
+      val errors   = diags.count(_.isError)
+      val warnings = diags.size - errors
+      IO(logger.warn(s"TASTy read for $buildTarget produced $errors error(s), $warnings warning(s)")) *>
+        Tracer[IO].currentSpanOrNoop.flatMap { span =>
+          span.addAttribute(Attribute("index.errors", errors.toLong)) *>
+            span.addAttribute(Attribute("index.warnings", warnings.toLong)) *>
+            IO.whenA(errors > 0)(span.setStatus(StatusCode.Error, s"indexed with $errors error(s)")) *>
+            diags.take(TastyIndexer.maxReportedDiagnostics).traverse_ { d =>
+              span.addEvent(if d.isError then "index.error" else "index.warning", Attribute("message", d.message))
+            }
+        }
+    }
 
   def indexFiles(
       tastyFiles: List[AbsolutePath],
       classpath: List[AbsolutePath],
-  ): IO[Map[SourceUri, (List[IndexedSymbol], List[SymbolReference])]] =
+  ): IO[Indexed] =
     IO.blocking(runInspector(tastyFiles.map(_.toNioPath.toString), Nil, classpath.map(_.toNioPath.toString)))
+      .flatMap { case (result, diags) => attachDiagnostics(diags).as(result) }
 
   def indexDirectory(
       classesDir: AbsolutePath,
       classpath: List[AbsolutePath],
-  ): IO[Map[SourceUri, (List[IndexedSymbol], List[SymbolReference])]] =
+  ): IO[Indexed] =
     IO.blocking {
       val tastyFiles = java.nio.file.Files
         .walk(classesDir.toNioPath)
@@ -37,28 +64,29 @@ class TastyIndexer(buildTarget: String) {
         .toList
         .map(_.asInstanceOf[java.nio.file.Path].toString)
       runInspector(tastyFiles, Nil, classpath.map(_.toNioPath.toString))
-    }
+    }.flatMap { case (result, diags) => attachDiagnostics(diags).as(result) }
 
   def indexJar(
       jarPath: AbsolutePath,
       classpath: List[AbsolutePath],
-  ): IO[Map[SourceUri, (List[IndexedSymbol], List[SymbolReference])]] =
+  ): IO[Indexed] =
     IO.blocking(runInspector(Nil, List(jarPath.toNioPath.toString), classpath.map(_.toNioPath.toString)))
+      .flatMap { case (result, diags) => attachDiagnostics(diags).as(result) }
 
   def indexBetastyJar(
       jarPath: AbsolutePath,
       classpath: List[AbsolutePath],
       onlyEntries: Set[String] = Set.empty,
-  ): IO[Map[SourceUri, (List[IndexedSymbol], List[SymbolReference])]] =
+  ): IO[Indexed] =
     IO.blocking {
       val tempDir = java.nio.file.Files.createTempDirectory("betasty-extract")
       try {
         val betastyFiles = extractBetastyFiles(jarPath, tempDir, onlyEntries)
-        if betastyFiles.isEmpty then Map.empty
+        if betastyFiles.isEmpty then (Map.empty, Nil)
         else runBetastyInspector(betastyFiles.map(_.toString), Nil, classpath.map(_.toNioPath.toString))
       } finally
         AbsolutePath(tempDir).deleteRecursively
-    }
+    }.flatMap { case (result, diags) => attachDiagnostics(diags).as(result) }
 
   /** Run the TASTy inspector. Re-throws any Throwable (including compiler Errors like AssertionError, LinkageError)
     * wrapped in a RuntimeException so cats-effect's IO.handleErrorWith can fire the bytecode fallback. Stdout is
@@ -68,18 +96,18 @@ class TastyIndexer(buildTarget: String) {
       tastyFiles: List[String],
       jars: List[String],
       classpath: List[String],
-  ): Map[SourceUri, (List[IndexedSymbol], List[SymbolReference])] = {
+  ): (Indexed, List[IndexDiagnostic]) = {
     val collector = new SymbolCollector(buildTarget)
     TastyIndexer.suppressedThreads.set(true)
-    try
-      TastyInspectorDriver.inspectTastyFiles(tastyFiles, jars, classpath)(collector)
-    catch {
-      case t: Throwable =>
-        val target = if jars.nonEmpty then jars.mkString(", ") else tastyFiles.take(3).mkString(", ")
-        throw new RuntimeException(s"TASTy inspector crash for $target", t)
-    } finally
-      TastyIndexer.suppressedThreads.set(false)
-    collector.result
+    val diags =
+      try TastyInspectorDriver.inspectTastyFiles(tastyFiles, jars, classpath)(collector)
+      catch {
+        case t: Throwable =>
+          val target = if jars.nonEmpty then jars.mkString(", ") else tastyFiles.take(3).mkString(", ")
+          throw new RuntimeException(s"TASTy inspector crash for $target", t)
+      } finally
+        TastyIndexer.suppressedThreads.set(false)
+    (collector.result, diags)
   }
 
   private def extractBetastyFiles(
@@ -111,25 +139,25 @@ class TastyIndexer(buildTarget: String) {
       betastyFiles: List[String],
       jars: List[String],
       classpath: List[String],
-  ): Map[SourceUri, (List[IndexedSymbol], List[SymbolReference])] = {
+  ): (Indexed, List[IndexDiagnostic]) = {
     logger.info(
       s"runBetastyInspector: ${betastyFiles.size} betasty files, ${jars.size} jars, ${classpath.size} classpath entries"
     )
     betastyFiles.foreach(f => logger.debug(s"  betasty file: $f"))
     val collector = new SymbolCollector(buildTarget)
     TastyIndexer.suppressedThreads.set(true)
-    try {
-      val success = TastyInspectorDriver.inspectBetastyFiles(betastyFiles, jars, classpath)(collector)
-      logger.info(s"TastyInspectorDriver.inspectBetastyFiles returned success=$success")
-    } catch {
-      case t: Throwable =>
-        val target = if jars.nonEmpty then jars.mkString(", ") else betastyFiles.take(3).mkString(", ")
-        logger.error(s"BeTASTy inspector crash for $target", t)
-    } finally
-      TastyIndexer.suppressedThreads.set(false)
+    val diags =
+      try TastyInspectorDriver.inspectBetastyFiles(betastyFiles, jars, classpath)(collector)
+      catch {
+        case t: Throwable =>
+          val target = if jars.nonEmpty then jars.mkString(", ") else betastyFiles.take(3).mkString(", ")
+          logger.error(s"BeTASTy inspector crash for $target", t)
+          Nil
+      } finally
+        TastyIndexer.suppressedThreads.set(false)
     val result = collector.result
     logger.info(s"runBetastyInspector result: ${result.size} files, ${result.values.map(_._1.size).sum} symbols")
-    result
+    (result, diags)
   }
 }
 
@@ -448,7 +476,13 @@ private class SymbolCollector(buildTarget: String) extends scala.tasty.inspector
 }
 
 object TastyIndexer {
-  def apply(buildTarget: String): TastyIndexer = new TastyIndexer(buildTarget)
+
+  /** Cap on how many TASTy diagnostics we attach as span events per jar, to keep a pathologically broken jar from
+    * flooding the trace. The error/warning counts are always exact; only the per-message events are capped.
+    */
+  private val maxReportedDiagnostics = 20
+
+  def apply(buildTarget: String)(using Tracer[IO]): TastyIndexer = new TastyIndexer(buildTarget)
 
   private val suppressedThreads: ThreadLocal[Boolean] = ThreadLocal.withInitial(() => false)
 

--- a/sls/src/org/scala/abusers/sls/index/TastyInspectorDriver.scala
+++ b/sls/src/org/scala/abusers/sls/index/TastyInspectorDriver.scala
@@ -6,7 +6,10 @@ import dotty.tools.dotc.core.Phases.Phase
 import dotty.tools.dotc.fromtasty.ReadTasty
 import dotty.tools.dotc.fromtasty.TASTYCompiler
 import dotty.tools.dotc.fromtasty.TASTYRun
+import dotty.tools.dotc.interfaces
 import dotty.tools.dotc.quoted.QuotesCache
+import dotty.tools.dotc.reporting.Diagnostic
+import dotty.tools.dotc.reporting.Reporter
 import dotty.tools.dotc.util.ClasspathFromClassloader
 import dotty.tools.dotc.CompilationUnit
 import dotty.tools.dotc.Compiler
@@ -19,6 +22,9 @@ import scala.quoted.runtime.impl.QuotesImpl
 import scala.tasty.inspector.Inspector
 import scala.tasty.inspector.Tasty
 
+/** A diagnostic dotc emitted while reading TASTy: an error or warning with a rendered, position-prefixed message. */
+final case class IndexDiagnostic(isError: Boolean, message: String)
+
 /** A low-level TASTy inspection driver that bypasses [[scala.tasty.inspector.TastyInspector]] to allow reading both
   * regular `.tasty` files and `.betasty` files produced by best-effort compilation (via `-Ywith-best-effort-tasty`).
   *
@@ -27,29 +33,49 @@ import scala.tasty.inspector.Tasty
   */
 object TastyInspectorDriver {
 
+  /** Returns the diagnostics dotc emitted while reading the TASTy (errors/warnings), captured rather than printed.
+    * Empty means a clean read. A non-empty list does **not** mean nothing was indexed — the inspector collects what it
+    * can past per-file errors; the diagnostics tell the caller the result is partial/degraded.
+    */
   def inspectTastyFiles(
       tastyFiles: List[String],
       jars: List[String],
       dependenciesClasspath: List[String],
-  )(inspector: Inspector): Boolean =
+  )(inspector: Inspector): List[IndexDiagnostic] =
     inspect(tastyFiles ::: jars, dependenciesClasspath, bestEffort = false)(inspector)
 
   def inspectBetastyFiles(
       betastyFiles: List[String],
       jars: List[String],
       dependenciesClasspath: List[String],
-  )(inspector: Inspector): Boolean =
+  )(inspector: Inspector): List[IndexDiagnostic] =
     inspect(betastyFiles ::: jars, dependenciesClasspath, bestEffort = true)(inspector)
 
   private def inspect(files: List[String], dependenciesClasspath: List[String], bestEffort: Boolean)(
       inspector: Inspector
-  ): Boolean =
+  ): List[IndexDiagnostic] =
     files match {
-      case Nil => true
+      case Nil => Nil
       case _   =>
-        val reporter = inspectorDriver(inspector).process(inspectorArgs(dependenciesClasspath, files, bestEffort))
-        !reporter.hasErrors
+        val reporter = new CollectingReporter
+        inspectorDriver(inspector).process(inspectorArgs(dependenciesClasspath, files, bestEffort), reporter, null)
+        reporter.collected
     }
+
+  /** A dotc [[Reporter]] that captures diagnostics (rendering message + position while the compiler context is still
+    * alive) instead of printing them to stderr — both to stop the red spew corrupting the user's view and to hand the
+    * structured errors back to the indexer.
+    */
+  private class CollectingReporter extends Reporter {
+    private val buf = scala.collection.mutable.ListBuffer.empty[IndexDiagnostic]
+
+    override def doReport(dia: Diagnostic)(using Context): Unit = {
+      val where = if dia.pos.exists then s"${dia.pos.source.name}:${dia.pos.startLine + 1}: " else ""
+      buf += IndexDiagnostic(isError = dia.level >= interfaces.Diagnostic.ERROR, message = where + dia.message)
+    }
+
+    def collected: List[IndexDiagnostic] = buf.toList
+  }
 
   private def inspectorDriver(inspector: Inspector) = {
     class InspectorDriver extends Driver {

--- a/sls/test/src/org/scala/abusers/sls/index/CrossProducerSpec.scala
+++ b/sls/test/src/org/scala/abusers/sls/index/CrossProducerSpec.scala
@@ -1,6 +1,7 @@
 package org.scala.abusers.sls.index
 
 import cats.effect.IO
+import org.typelevel.otel4s.trace.Tracer
 import weaver.*
 
 /** Verifies that TastyIndexer, BytecodeIndexer, and JavaIndexer emit the same SymbolId for the same source-level
@@ -14,6 +15,8 @@ import weaver.*
   * removes that drift; the tests run for real now.
   */
 object CrossProducerSpec extends SimpleIOSuite {
+
+  private given Tracer[IO] = Tracer.noop[IO]
 
   private def tastySymbols: IO[List[IndexedSymbol]] =
     TastyIndexer("test").indexJar(IndexTestFixtures.crossProducerJar, Nil).map(_.values.flatMap(_._1).toList)

--- a/sls/test/src/org/scala/abusers/sls/index/IndexManagerSpec.scala
+++ b/sls/test/src/org/scala/abusers/sls/index/IndexManagerSpec.scala
@@ -6,6 +6,7 @@ import org.objectweb.asm.ClassWriter
 import org.objectweb.asm.Opcodes
 import org.scala.abusers.sls.AbsolutePath
 import org.scala.abusers.sls.SourceUri
+import org.typelevel.otel4s.trace.Tracer
 import weaver.*
 
 import java.io.FileOutputStream
@@ -14,6 +15,8 @@ import java.util.zip.ZipOutputStream
 
 object IndexManagerSpec extends SimpleIOSuite {
 
+  private given Tracer[IO] = Tracer.noop[IO]
+
   private val bytecodeIndexer = BytecodeIndexer()
 
   private def withManager[A](
@@ -21,9 +24,9 @@ object IndexManagerSpec extends SimpleIOSuite {
   ): IO[A] =
     Supervisor[IO].use { sup =>
       for {
-        pi <- ProjectIndex.empty
-        di <- DependencyIndex.empty
-        lc <- IndexLifecycle.empty
+        pi       <- ProjectIndex.empty
+        di       <- DependencyIndex.empty
+        lc       <- IndexLifecycle.empty
         cacheDir <- IO.blocking(os.temp.dir(prefix = "index-manager-test-cache").toNIO)
         mgr = IndexManager(
           SymbolIndex(pi, di),
@@ -95,8 +98,8 @@ object IndexManagerSpec extends SimpleIOSuite {
   test("dependency JAR indexed via bytecode — symbols findable") {
     val cls = javaClass("com/example/Widget")
     for {
-      jar <- createJar(List(cls))
-      di  <- DependencyIndex.empty
+      jar   <- createJar(List(cls))
+      di    <- DependencyIndex.empty
       syms  <- bytecodeIndexer.indexJar(jar)
       _     <- di.addJar(jar.toNioPath.toString, syms)
       found <- di.searchSymbols("widget")

--- a/sls/test/src/org/scala/abusers/sls/index/TastyIndexerSpec.scala
+++ b/sls/test/src/org/scala/abusers/sls/index/TastyIndexerSpec.scala
@@ -2,12 +2,15 @@ package org.scala.abusers.sls.index
 
 import cats.effect.IO
 import org.scala.abusers.sls.SourceUri
+import org.typelevel.otel4s.trace.Tracer
 import weaver.*
 
 /** Indexes the pre-compiled `tastyIndexerFixture` JAR published to `~/.m2` by `sls.test.forkArgs` — see
   * `IndexTestFixtures`. No dotc at test time.
   */
 object TastyIndexerSpec extends SimpleIOSuite {
+
+  private given Tracer[IO] = Tracer.noop[IO]
 
   private def indexFixture: IO[Map[SourceUri, (List[IndexedSymbol], List[SymbolReference])]] =
     TastyIndexer("test-target").indexJar(IndexTestFixtures.tastyIndexerJar, Nil)

--- a/sls/test/src/org/scala/abusers/sls/index/util/TestWorkspace.scala
+++ b/sls/test/src/org/scala/abusers/sls/index/util/TestWorkspace.scala
@@ -7,9 +7,12 @@ import dotty.tools.dotc.util.ClasspathFromClassloader
 import org.scala.abusers.sls.toSourceUri
 import org.scala.abusers.sls.AbsolutePath
 import org.scala.abusers.sls.SourceUri
+import org.typelevel.otel4s.trace.Tracer
 
 import java.io.File.pathSeparator
 import java.nio.file.Paths
+
+private given Tracer[IO] = Tracer.noop[IO]
 
 /** A temp workspace whose sources were compiled with in-process dotc, ready to be indexed.
   *
@@ -44,8 +47,8 @@ final case class TestWorkspace(
 object TestWorkspace {
 
   /** Compile `name -> source` pairs into a temp workspace via in-process `dotty.tools.dotc.Main`, against the test
-    * runtime classpath. Acquisition fails if compilation fails (diagnostics go to the console). The temp directory
-    * is removed on release.
+    * runtime classpath. Acquisition fails if compilation fails (diagnostics go to the console). The temp directory is
+    * removed on release.
     */
   def withSources(srcs: (String, String)*): Resource[IO, TestWorkspace] =
     Resource.make(IO.blocking {
@@ -64,10 +67,9 @@ object TestWorkspace {
       val cpString = ClasspathFromClassloader(getClass.getClassLoader)
       val args     = Array("-d", classesDir.toString, "-classpath", cpString) ++ files.values.map(_.toString)
       val reporter = dotty.tools.dotc.Main.process(args)
-      if reporter.hasErrors then
-        throw new RuntimeException(
-          s"TestWorkspace compilation failed with ${reporter.errorCount} error(s) — see console output"
-        )
+      if reporter.hasErrors then throw new RuntimeException(
+        s"TestWorkspace compilation failed with ${reporter.errorCount} error(s) — see console output"
+      )
 
       val classpath = cpString.split(pathSeparator).toList.filter(_.nonEmpty).map(p => AbsolutePath(Paths.get(p)))
       TestWorkspace(sourceRoot, classesDir, files, classpath)


### PR DESCRIPTION
## What

Threads tracing and failure-surfacing through the index + LSP layers, plus a Java-frontend correctness fix. (Originally stacked on #92; rebased onto `main` now that #92 is merged.)

- **Client error surfacing** — `ServerImpl.op(name)(fa)` wraps every LSP op in a span and, on failure, pushes the full stacktrace to the client Output channel (`window/logMessage`, Error) so it's visible in the editor without the trace backend. New `LoggingUtils.logError`.
- **Indexing spans** — `IndexManager` / `TastyIndexer` / `SymbolIndexer` now take `Tracer[IO]`; `bootstrap` opens an `index.bootstrap` root span and each library nests under an `index.jar` span carrying symbol counts and recording exceptions.
- **TASTy diagnostics** — `TastyIndexer` returns `(Indexed, List[IndexDiagnostic])` and attaches TASTy read errors/warnings to the current span.
- **`JavaFrontendDriver` fix** — type-check against a fresh `StoreReporter` rather than leaking the caller's reporter state.

## Test

`./mill __.compile` clean; `./mill sls.test` 598/598 green.

Note: under the heavier `./mill _.test` (all modules in parallel) the timing-sensitive `DidSaveCompileConcurrencySpec` (300ms window, from #92) can flake. Not touched by this PR — worth making that spec load-robust separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)