### PR TITLE
chore: add ai design notes; gitignore local tooling/caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ out
 .direnv
 .claude/settings.local.json
 .mcp.json
+
+# local tooling / caches
+.cellar
+.sls
+langoustine-tracer

--- a/ai/progress-system.md
+++ b/ai/progress-system.md
@@ -1,0 +1,174 @@
+# Progress & status system: surfacing work and failures to the user
+
+## Context
+
+SLS must never fail silently — the recurring complaint about other tools. Today the user-facing
+channels are thin and the structured signal we *do* have is invisible to users:
+
+- The smithy client service (`slsSmithy/smithy/lsp.smithy`) exposes only `window/logMessage`,
+  `window/showMessage`, and `textDocument/publishDiagnostics`. No `$/progress`, no status item.
+- `IndexLifecycle` is a single coarse `Cold → Bootstrapping → Ready → Failed` `SignallingRef`.
+  `Failed` is binary: one library failing to index is either swallowed (`indexJarSafely` logs and
+  moves on) or, if it escaped, would nuke the whole phase. There is no per-item detail.
+- `IndexManager.notifyProgress` just `toString`s into `window/logMessage`.
+- otel `Tracer[IO]` is threaded through `ServerImpl`/`IndexManager`, but it is a dev/ops sink
+  (external backend) — users never see it.
+
+The seed idea was "an Index trace that stores each library as a span." That generalizes into a
+single status model with many projections.
+
+---
+
+## Core idea: one status model, many sinks
+
+Model long-running or fallible work as an **Activity** (≈ a span); children link to a parent to form
+a tree (≈ a trace). Decouple the *model* from the *transports*. The LSP progress bar, a status-bar
+item, a drill-down document, and the otel trace are all **projections of the same tree**, so they
+can't drift.
+
+### The model — `Activity`
+
+```
+Activity:
+  id, parent              // tree → "trace"
+  kind: Index | Compile | Bsp | Pc | Resolve   // extensible enum
+  label                   // "Index bootstrap", "cats-core_3-2.13.0.jar", "Compile sls"
+  severity: Info | Warning | Error             // how loud, orthogonal to status
+  status: Pending | Running | Succeeded | Skipped | Failed(message, cause)
+  detail, startedAt, endedAt
+```
+
+Two deliberate separations:
+
+- **status vs severity.** A library that fails to index is `Failed` + `Warning` (degraded, the
+  server lives); a failed compile is `Failed` + `Error`. Sinks route on severity (log vs toast).
+- **Rollup.** A parent reflects its children: `Index bootstrap` becomes "Ready — 3 of 200 libraries
+  failed" instead of a silent drop or a hard `Failed`. This rollup is the anti-silent-failure win.
+
+### The hub — `StatusManager` (single funnel)
+
+Owns the tree (`Ref[IO, Map[ActivityId, Activity]]`) plus an event `Topic[IO, Activity]`. API:
+
+```
+start(kind, label, parent, severity): IO[ActivityId]
+succeed(id, detail) / skip(id, reason) / fail(id, cause, message): IO[Unit]
+scoped(kind, label, parent)(use: ActivityId => IO[A]): IO[A]   // guaranteeCase wrapper
+snapshot: IO[Vector[Activity]]
+changes: Stream[IO, Activity]
+```
+
+**Every fallible or long-running operation reports here.** That single rule is what kills silent
+failures. A new subsystem just emits Activities; it doesn't know who's listening.
+
+### The sinks — independent subscribers
+
+| Sink | Channel | Behaviour |
+|---|---|---|
+| **Log** | `window/logMessage` | every transition, full detail (works today, no protocol change) |
+| **Progress** | `$/progress` + `window/workDoneProgress/create` | Running roots → live bar: "Indexing 45/200 — cats-core" |
+| **Notification** | `window/showMessage(Request)` | only `Error` / aggregated `Warning`; debounced/rolled up → one "Indexing finished, 3 errors" toast, never 50 |
+| **Status item** | custom `sls/status` notification | status-bar: Ready ✓ / Indexing ⟳ / Degraded ⚠ (N). Click → `sls/showStatus` |
+| **otel** | `Tracer` | Activity → span, same parent/child + status. The dev trace is *derived from* the same model |
+
+Drill-down: `sls/showStatus` (a `workspace/executeCommand`) renders the tree to a markdown virtual
+document via `window/showDocument`, failures expanded with the real cause
+(e.g. "guava-32.jar: failed to read TASTy — NoSuchFileException").
+
+### otel mapping (the trace sink)
+
+`Tracer[IO]` is already wired, so spans are nearly free and make the user-facing tree and the otel
+trace one structure:
+
+- `start` → `Tracer[IO].spanBuilder(label).withParent(parentCtx).build.startUnmanaged`, stash the
+  `Span[IO]` by `ActivityId` (`startUnmanaged` because our lifecycle is imperative start/end).
+- `fail` → `span.recordException(cause) *> span.setStatus(Error) *> span.end`; `succeed` →
+  `setStatus(Ok).end`.
+- Parent/child via the **stored `SpanContext`**, passed explicitly — sinks run on separate fibers,
+  so we cannot rely on fiber-local context propagation for the general case.
+
+(Note: when the *producer's own work* runs inside a span scope — as in the slice below — fiber-local
+propagation already nests children correctly without the manual `SpanContext` plumbing. The manual
+path is only needed when the otel sink reconstructs spans off the `changes` stream.)
+
+---
+
+## Why it scales
+
+The same machinery later surfaces, with no new infra:
+
+- **Compile failure** — `Compile` activity, `Error`, links the target (currently `didSave` compile
+  errors are swallowed in `ServerImpl.handleDidSave`).
+- **BSP/CSP disconnect** — `Bsp` activity with a "Reconnect" action via `showMessageRequest`.
+- **PC load failure per Scala version** — `Pc` activity, `Warning` (that version's editor features
+  degrade, the server lives).
+
+`IndexLifecycle` then becomes a *projection* of the Index root activity's rollup rather than a
+parallel state machine.
+
+---
+
+## Decisions (made during design)
+
+- **Surface: full** — add `$/progress` AND a custom `sls/status` item + `sls/showStatus` drill-down,
+  not just standard progress.
+- **First slice: index only, end to end.**
+- **Client: server-side first.** Land the protocol + server (progress works in any client; `sls/status`
+  + `sls/showStatus` are emitted and tested at the wire level); wire the actual status-bar item in the
+  editor client as a follow-up.
+- **Trace sink: include from day one** (Tracer already wired).
+
+## Protocol additions (all shapes already exist in `lsp-smithy-definitions` 0.2.0)
+
+Only operations need wiring — no new shape authoring:
+
+- `SlsLanguageClient` += `lsp#Progress` (`$/progress`), `lsp#WindowWorkDoneProgressCreate`,
+  `lsp#WindowShowMessageRequestOp`, `lsp#WindowShowDocument`.
+- `SlsLanguageServer` += `lsp#WorkspaceExecuteCommandOp` (for `sls/showStatus`).
+- One tiny custom shape for the status-item notification: `sls/status → StatusParams{ state, label, detail }`.
+
+## Rollout (each step independently shippable)
+
+1. `Activity` model + `StatusManager` (no protocol change, unit-testable) — the keystone.
+2. Sinks: Log + otel (no protocol change), then Progress, then Status item.
+3. smithy operations.
+4. Index integration: `IndexManager.bootstrap` root activity, per-library children, rollup;
+   `IndexLifecycle` becomes a projection; delete `notifyProgress`.
+5. TestClient capture (progress + `sls/status`) + tests: a failing library → `Degraded` rollup + a
+   captured failure; progress begins/ends.
+
+---
+
+## Implemented so far
+
+Only the otel spans — the minimal, immediately-useful piece (`IndexManager`):
+
+- `index.bootstrap` — root span of the index trace (attribute: `index.targets`).
+- `index.jar <library>` — one span per library under `indexJarSafely`, **named after the jar**
+  (e.g. `index.jar cats-core_3-2.13.0.jar`) so the trace tree is scannable; the full path is also on
+  the `index.jar` attribute. Nested under the root via fiber-local context propagation (the
+  `parEvalMapUnordered` fibers inherit the bootstrap scope). On a hard crash the exception is recorded
+  on the span (`recordException`) and the status set to `Error`; the failure is still swallowed (a bad
+  jar degrades that library, it doesn't fail the bootstrap). Attribute `index.symbols` records how
+  many symbols the jar contributed.
+
+- **Partial-failure capture (the "indexed but with errors" case).** Reading a jar's TASTy against a
+  slightly-wrong classpath makes dotc emit per-file typer errors *but keep going*, so the jar indexes
+  partially and used to look like a clean success while the errors spewed to stderr. Now
+  `TastyInspectorDriver` installs a `CollectingReporter` (a dotc `Reporter`) passed to
+  `Driver.process(args, reporter, …)` — which (a) **stops the stderr spew** and (b) hands the
+  diagnostics back as `List[IndexDiagnostic]`. `TastyIndexer.attachDiagnostics` records them on the
+  *current* span (`Tracer.currentSpanOrNoop`, i.e. the `index.jar` span): `index.errors` /
+  `index.warnings` counts, the first 20 messages as `index.error`/`index.warning` span events, and
+  `setStatus(Error)` when any error was seen — so a partially-indexed jar stands out in the trace
+  instead of masquerading as clean. Also logged (`logger.warn`) so the signal survives with no trace
+  backend attached. `TastyIndexer` / `SymbolIndexer.tasty` now take `(using Tracer[IO])`.
+
+  Open follow-up (deliberately deferred): whether `index.errors > 0` should *trigger the bytecode
+  fallback* for that jar (partial TASTy may be worse than complete bytecode) — that's a strategy
+  decision in `runStrategy`, not just surfacing.
+
+`IndexManager` now takes `(using Tracer[IO])`; prod/integration wiring supplies the real tracer,
+`IndexManagerSpec` supplies `Tracer.noop[IO]`.
+
+**Not yet built:** `StatusManager`, the Activity model, the non-otel sinks, the protocol operations,
+and the `IndexLifecycle`-as-projection change. This document is the plan of record for them.

--- a/ai/trace-inspector.md
+++ b/ai/trace-inspector.md
@@ -1,0 +1,73 @@
+# In-editor trace/telemetry inspector for SLS (langoustine-style)
+
+> Status: **design only, not implemented.** Plan of record for when we pick this up. The user works
+> with Grafana for now.
+
+## Context
+
+SLS already emits otel spans for every LSP op (`op(name)` in `ServerImpl`) and for indexing
+(`index.bootstrap`, `index.jar <library>`, with attributes/events incl. captured exceptions). Today the
+only way to see them as traces is Grafana (OTLP export) — out of editor, needs a collector. The user
+already runs **langoustine-tracer** (which wraps the server in `slc`'s run mode and shows LSP JSON-RPC
+traffic in a Scala.js/Laminar web UI on a random port), but it knows nothing about *our* otel spans +
+metadata. The goal: a **langoustine-style inspector for our telemetry** — spans, their attributes/events,
+and trace waterfalls — viewable inside VS Code.
+
+Decisions made with the user:
+- **Deliver via an embedded HTTP server in SLS** (the langoustine model), not a VS Code-native webview app.
+- **Frontend in Scala.js + Laminar** — exactly what langoustine-tracer uses; all-Scala, served by http4s.
+- **Integrate through the existing `slc` extension** (`/home/rochala/Projects/sls/slc`): a thin command opens the dashboard URL (it already has the `sls/debugIndex` command + launches via `langoustine-tracer`).
+- Self-contained: no external collector; OTLP→Grafana export keeps working in parallel (we *add* a span processor).
+- Related to but separate from `ai/progress-system.md` (user-facing StatusManager) — this is a dev tool.
+
+## Verified facts
+- **langoustine-tracer** = Scala.js + **Laminar** frontend + embedded HTTP server, binds a random port (neandertech.github.io/langoustine/tracer.html). This is the model to mirror.
+- **otel pipeline** (`profilingRuntime/.../ProfilingIOApp.scala`): `OpenTelemetrySdk.autoConfigured` with `.addTracerProviderCustomizer(_.addSpanProcessor(new ProfilingSpanProcessor))`. `ProfilingSpanProcessor.onEnd` is a **no-op** — the capture hook. otel4s 0.13.1: `SpanData` exposes name/spanContext(`traceIdHex`/`spanIdHex`)/parentSpanContext/start+endTimestamp(`FiniteDuration`)/status(`StatusData` w/ `.description`)/attributes/events(`.elements`).
+- **http4s/circe NOT on classpath yet** — must be added. **logback.xml is FileAppender-only** (no stdout appender) — http4s SLF4J logs won't corrupt the JSON-RPC pipe.
+- **`slc`** = thin TS extension (single `client/src/extension.ts`, plain `tsc`, `vscode-languageclient@9`, no bundler/webviews). Launches server via `../sls/langoustine-tracer <jar>` (run) or `java -D... -jar <jar>` (debug). Already registers the `sls/debugIndex` command + a `TextDocumentContentProvider` virtual doc.
+- **Mill 1.1.6** supports Scala.js via `mill.scalajslib.ScalaJSModule` (`scalaJSVersion`, `fastLinkJS`/`fullLinkJS`). VERIFY exact task/report API + a Laminar version for Scala 3 + circe Scala.js artifact during implementation.
+
+## Approach — four pieces
+
+### 1. Span capture (in `profilingRuntime`)
+- `TraceBuffer.scala`: serializable model `TraceSpan(traceId, spanId, parentSpanId: Option, name, kind, startNanos, endNanos, statusCode, statusDescription, attributes: Map[String,String], events: List[TraceEvent(name, tsNanos, attributes)])`; pure `fromSpanData(sd)` (unit-testable) using the verified accessors (`attrs.map(a => a.key.name -> a.value.toString).toMap`, match on `StatusData` subtypes). Holder = drop-oldest ring `Ref[IO, Vector[TraceSpan]]` (cap ~2000) + `fs2.concurrent.Topic[IO, TraceSpan]` for live SSE; `add` updates ring + `topic.publish1` (non-blocking, safe on the `onEnd` hot path); `snapshot`.
+- `TraceBufferSpanProcessor(buffer) extends SpanProcessor[IO]`: `onEnd = sd => buffer.add(TraceSpan.fromSpanData(sd))`; others no-op. Composed by a second `builder.addSpanProcessor(...)` call (keep `ProfilingSpanProcessor`).
+
+### 2. Backend HTTP server (in `profilingRuntime`)
+- `TraceViewerServer.resource(buffer, host, port): Resource[IO, Server]` via `EmberServerBuilder`, bound **127.0.0.1 only**. Routes:
+  - `GET /api/traces` → `Ok(buffer.snapshot)` JSON (circe; flat list, client groups by traceId).
+  - `GET /api/stream` → SSE from `buffer.topic.subscribe(256)` + 15s keepalive comment.
+  - `GET /` and `GET /assets/*` → serve `index.html` + the linked Scala.js bundle from **classpath resources** (`trace-ui/`), so it ships in the `sls` assembly jar.
+- Port from `SLS_TRACE_UI_PORT` (default **8682**); print `http://127.0.0.1:<port>` to **stderr** (`Console[IO].errorln`). circe `deriveEncoder` for the model.
+- build.mill: add `http4s-ember-server`, `http4s-dsl`, `http4s-circe` (0.23.30), `circe-core`/`circe-generic` (0.14.14), explicit `ip4s-core` to `profilingRuntime.mvnDeps`. (Accept the published-artifact weight; split to a `traceViewer` module later if it matters.)
+
+### 3. Frontend — new Scala.js module `traceUi` (Laminar)
+- New `object traceUi extends ScalaJSModule` in build.mill: `scalaJSVersion`, deps `com.raquo::laminar::<ver>` + `io.circe::circe-core::<ver>` (+ `circe-parser`) Scala.js artifacts. Scala 3.
+- Laminar app (`traceUi/src/.../Main.scala`): on load `fetch('/api/traces')`; live via `new EventSource('/api/stream')` (small Scala.js facade or `org.scalajs.dom.EventSource`). State in `Var`/`Signal`. Render, langoustine-style:
+  - **Left: trace list** (group by `traceId`, root span name + total duration + span count, newest first).
+  - **Right: waterfall** for the selected trace — build the tree from `parentSpanId`, one row per span indented by depth, a bar `left=(start-t0)/T`, `width=(end-start)/T`; red when `statusCode=="ERROR"`.
+  - **Detail panel** on span click: attributes table + events (the `exception` event shows `exception.message`/`exception.stacktrace` — the "metadata").
+- **Model sharing**: v1 = a frontend-local `TraceSpan`/`TraceEvent` + circe decoder matching the server JSON (~10 lines dup). Refinement: extract a cross-built (`JVM`+`JS`) `traceModel` module as the single source of truth.
+
+### 4. Wiring & gating
+- `ProfilingIOAppSettings.traceUiEnabled` (env `SLS_TRACE_UI` / `-Dsls.trace.ui`), independent of `SLS_PROFILING`.
+- `ProfilingIOApp.run` (the one ordering constraint): create `TraceBuffer` **first**, then build the SDK resource whose customizer closes over it and (gated) adds `TraceBufferSpanProcessor`; (gated) acquire `TraceViewerServer.resource(buffer, host"127.0.0.1", port)` as another `Resource` step in the same `use`. Off → byte-for-byte current behavior, zero overhead.
+- **build.mill bundling task**: a task on the server module that runs `traceUi.fullLinkJS` and copies the linked `main.js` (+ map) into `profilingRuntime` resources `trace-ui/` next to a static `index.html`, so the assembly contains the bundle. (This build step is the main risk — verify Mill 1.x `fullLinkJS` output/report shape early.)
+- **`slc`** (`client/src/extension.ts`): add command `sls.openTraceInspector` → open `http://127.0.0.1:8682` via `commands.executeCommand('simpleBrowser.show', url)` (fallback `env.openExternal`). Register in `package.json` `contributes.commands`. Enable the flag in the launched server: add `-Dsls.trace.ui=true` to the debug `args` and/or set `SLS_TRACE_UI` in the run env (langoustine-tracer inherits env). Port is the fixed default (optionally a `contributes.configuration` setting mirrored to `SLS_TRACE_UI_PORT`).
+
+## Pitfalls
+- **stdout = JSON-RPC pipe**: http4s logs via SLF4J→logback (FileAppenders only — verified); URL to stderr; audit new files for `println`/`System.out`.
+- **Assembly must contain the JS bundle** — the build task ordering (link Scala.js → copy into JVM resources → assembly) is load-bearing; verify in a clean `./mill sls.assembly`.
+- In-process buffer only captures this JVM's spans (all `index.*` + LSP `op(...)`; the `zincCli` subprocess won't appear — out of scope).
+- Memory bounded by ring cap + `subscribe(256)` backpressure. OTLP export unaffected (added, not replaced).
+- Port coordination: fixed default 8682 shared by server + `slc`; make it a setting if needed.
+
+## Critical files
+- Edit: `build.mill` (deps + new `traceUi` ScalaJSModule + JS-bundling task), `profilingRuntime/.../ProfilingIOApp.scala` (+ `ProfilingIOAppSettings`), `slc/client/src/extension.ts` + `slc/package.json`.
+- New: `profilingRuntime/.../TraceBuffer.scala`, `TraceViewerServer.scala`, `profilingRuntime/resources/trace-ui/index.html`; `traceUi/src/.../Main.scala` (Laminar).
+- Reference: `profilingRuntime/.../ProfilingSpanProcessor.scala` (style), `sls/resources/logback.xml` (no stdout appender), `slc/client/src/extension.ts` (`sls/debugIndex` command precedent).
+
+## Verification
+**Build:** `./mill traceUi.fullLinkJS` then `./mill sls.assembly`; confirm the bundle lands in resources and the jar.
+**E2E:** launch with `SLS_TRACE_UI=true` (via `slc` debug args or `./mill sls.run`); confirm `http://127.0.0.1:8682` prints to **stderr** and stdout stays pure JSON-RPC (editor + langoustine-tracer still clean). Run `slc`'s `SLS: Open Trace Inspector` → Simple Browser shows the inspector. Open a Scala file (→ `index.bootstrap`) and request completion/inlay-hints (→ `op` spans); confirm the nested waterfall, and that the known inlay-hint crash shows a **red** span with its `exception` event (message + stacktrace) in the detail panel. Confirm SSE live-streams new spans without reload, and that running without the flag changes nothing.
+**Unit (Weaver, `profilingRuntime/test`):** `TraceSpan.fromSpanData` mapping (incl. `StatusData.Error`→`"ERROR"`+description, attribute/event flattening) from a hand-built `SpanData`; `TraceBuffer` ring-cap drop-oldest. (No compiler/type-system tests, per project rules.)


### PR DESCRIPTION
Housekeeping split out of the working tree after #92/#93.

- Adds two design notes under `ai/` (`progress-system.md`, `trace-inspector.md`) next to the existing `ai/roadmap.md` etc.
- Gitignores local-only artifacts that were cluttering `git status`: `.cellar`, `.sls` (build caches) and `langoustine-tracer` (the local LSP-trace launcher binary).

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)