### PR TITLE
PC version override: decouple PC artifact version from build target

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,20 @@ You should have langoustine-tracer launcher in server root.
 ```bash
 cs bootstrap tech.neander:langoustine-tracer_3:latest.release -f -o langoustine-tracer
 ```
+
+## Debugging the presentation compiler
+
+The PC is loaded from `org.scala-lang:scala3-presentation-compiler_3` at the build target's own
+Scala version. To test a different PC build (e.g. a locally `publishLocal`-ed dotty), override the
+version at launch — no recompile:
+
+```bash
+# all modules
+SLS_PC_VERSION=3.8.4-RC1-bin-SNAPSHOT ./mill sls.run        # or -Dsls.pc.version=...
+
+# per module (keyed by build-target display name); falls back to SLS_PC_VERSION, then the target's version
+SLS_PC_VERSIONS='sls=3.8.4-RC1-bin-SNAPSHOT,zincCli=3.8.3' ./mill sls.run   # or -Dsls.pc.versions=...
+```
+
+Coursier's `ivy2Local` is on the default resolver, so a `publishLocal`-ed snapshot resolves directly.
+An active override is logged per module on PC creation.

--- a/build.mill
+++ b/build.mill
@@ -94,7 +94,7 @@ object sls extends CommonScalaModule {
     mvn"ch.qos.logback:logback-classic:1.4.14",
     mvn"com.lihaoyi::os-lib:0.11.4",
     mvn"org.polyvariant.smithy4s-bsp::bsp4s:0.6.0",
-    mvn"org.scalameta:mtags-interfaces:1.6.3",
+    mvn"org.scalameta:mtags-interfaces:1.6.7",
     mvn"com.evolution::scache:5.1.2",
     mvn"org.typelevel::cats-parse:1.1.0",
     mvn"io.get-coursier:interface:1.0.28",

--- a/sls/src/org/scala/abusers/sls/ServerImpl.scala
+++ b/sls/src/org/scala/abusers/sls/ServerImpl.scala
@@ -326,6 +326,11 @@ class ServerImpl(
   implicit val rangeTransformer: Transformer[lsp4j.Range, lsp.Range] =
     Transformer.define[lsp4j.Range, lsp.Range].enableBeanGetters.buildTransformer
 
+  // Newer lsp4j models Diagnostic.message as Either[String, MarkupContent]; lsp.Diagnostic.message is a plain String.
+  implicit val diagnosticMessageTransformer
+      : Transformer[lsp4j.jsonrpc.messages.Either[String, lsp4j.MarkupContent], String] =
+    e => if e.isLeft then e.getLeft else e.getRight.getValue
+
   val handleDidChange: SynchronizedState ?=> lsp.DidChangeTextDocumentParams => IO[Unit] = {
     val debounce = Debouncer(250.millis)
 

--- a/sls/src/org/scala/abusers/sls/pc/PcParentClassLoader.scala
+++ b/sls/src/org/scala/abusers/sls/pc/PcParentClassLoader.scala
@@ -1,23 +1,11 @@
 package org.scala.abusers.pc
 
-/** Parent classloader for the presentation compiler's `URLClassLoader`.
-  *
-  * The host (sls) bundles a `scala3-compiler` of its own (transitively, via `scala3-tasty-inspector`), so
-  * `dotty.tools.dotc.*` — including `InteractiveDriver` — lives on the host's application classloader. A plain
-  * `URLClassLoader(pcJars, host)` delegates parent-first, so those compiler classes would load from the host's version
-  * while the PC impl (`dotty.tools.pc.*`, only on the PC jars) loads from the PC's version. When the two versions differ
-  * (e.g. a [[PcVersionOverride]], or simply a project on a different Scala version) they are binary-incompatible —
-  * `dotty.tools.pc.CachingDriver` calling `new InteractiveDriver(...)` blows up with `NoSuchMethodError`.
-  *
-  * This classloader has the bootstrap loader as its parent (so only JDK classes resolve through it) and delegates
-  * exactly the host↔PC bridge packages to the host loader, so those types keep a single class identity across the
-  * boundary. Everything else — notably `dotty.tools.*` and the Scala stdlib — is hidden, forcing the PC's
-  * `URLClassLoader` to load it from the PC's own jars.
+/** Parent for the PC's `URLClassLoader`. Parent is the bootstrap loader, so `dotty.tools.*` and the stdlib load from
+  * the PC's own jars (not sls's bundled scala3-compiler). Only the host<->PC bridge packages delegate to the host, so
+  * they keep one class identity across the boundary.
   */
 final class PcParentClassLoader(host: ClassLoader) extends ClassLoader(null) {
 
-  // Types that cross the sls<->PC boundary (see PresentationCompilerDTOInterop): the mtags PC API, the lsp4j types
-  // it returns, and gson (lsp4j's json layer). These must resolve to the host's classes, not the PC jars' copies.
   private val sharedPrefixes = List("scala.meta.pc.", "org.eclipse.lsp4j", "com.google.gson")
 
   override def findClass(name: String): Class[?] =

--- a/sls/src/org/scala/abusers/sls/pc/PcParentClassLoader.scala
+++ b/sls/src/org/scala/abusers/sls/pc/PcParentClassLoader.scala
@@ -1,0 +1,26 @@
+package org.scala.abusers.pc
+
+/** Parent classloader for the presentation compiler's `URLClassLoader`.
+  *
+  * The host (sls) bundles a `scala3-compiler` of its own (transitively, via `scala3-tasty-inspector`), so
+  * `dotty.tools.dotc.*` — including `InteractiveDriver` — lives on the host's application classloader. A plain
+  * `URLClassLoader(pcJars, host)` delegates parent-first, so those compiler classes would load from the host's version
+  * while the PC impl (`dotty.tools.pc.*`, only on the PC jars) loads from the PC's version. When the two versions differ
+  * (e.g. a [[PcVersionOverride]], or simply a project on a different Scala version) they are binary-incompatible —
+  * `dotty.tools.pc.CachingDriver` calling `new InteractiveDriver(...)` blows up with `NoSuchMethodError`.
+  *
+  * This classloader has the bootstrap loader as its parent (so only JDK classes resolve through it) and delegates
+  * exactly the host↔PC bridge packages to the host loader, so those types keep a single class identity across the
+  * boundary. Everything else — notably `dotty.tools.*` and the Scala stdlib — is hidden, forcing the PC's
+  * `URLClassLoader` to load it from the PC's own jars.
+  */
+final class PcParentClassLoader(host: ClassLoader) extends ClassLoader(null) {
+
+  // Types that cross the sls<->PC boundary (see PresentationCompilerDTOInterop): the mtags PC API, the lsp4j types
+  // it returns, and gson (lsp4j's json layer). These must resolve to the host's classes, not the PC jars' copies.
+  private val sharedPrefixes = List("scala.meta.pc.", "org.eclipse.lsp4j", "com.google.gson")
+
+  override def findClass(name: String): Class[?] =
+    if sharedPrefixes.exists(name.startsWith) then host.loadClass(name)
+    else throw new ClassNotFoundException(name)
+}

--- a/sls/src/org/scala/abusers/sls/pc/PcVersionOverride.scala
+++ b/sls/src/org/scala/abusers/sls/pc/PcVersionOverride.scala
@@ -1,30 +1,20 @@
 package org.scala.abusers.pc
 
-/** Debugging knob: override which `scala3-presentation-compiler_3` version the PC is loaded from, decoupled from the
-  * build target's own Scala version. Resolved once at startup from system properties (env vars as fallback), so it is
-  * toggled per launch with no recompile — same `-Dsls.*` convention as `sls.profiling`.
-  *
-  *   - `-Dsls.pc.version=<v>` (env `SLS_PC_VERSION`): global default applied to every module.
-  *   - `-Dsls.pc.versions=<module>=<v>,<module>=<v>` (env `SLS_PC_VERSIONS`): per-module map, keyed by build-target
-  *     display name; takes precedence over the global default.
-  *
-  * Resolution for a module is: per-module entry, else global default, else the target's own Scala version. Combined
-  * with coursier's `ivy2Local` default repository this makes a locally `publishLocal`-ed PC build directly usable.
+/** Overrides the `scala3-presentation-compiler_3` version, decoupled from the build target's Scala version. Per-module
+  * (`-Dsls.pc.versions=mod=ver,...` / `SLS_PC_VERSIONS`, keyed by display name) over a global (`-Dsls.pc.version` /
+  * `SLS_PC_VERSION`); falls back to the target's own version.
   */
 final case class PcVersionOverride(perModule: Map[String, String], global: Option[String]) {
 
-  /** Effective PC artifact version for `module`, falling back to `default` (the target's own Scala version). */
   def resolve(module: String, default: ScalaVersion): ScalaVersion =
     perModule.get(module).orElse(global).map(ScalaVersion(_)).getOrElse(default)
-
-  val isActive: Boolean = perModule.nonEmpty || global.isDefined
 }
 
 object PcVersionOverride {
 
   val empty: PcVersionOverride = PcVersionOverride(Map.empty, None)
 
-  /** Parse a `module=version,module=version` list; malformed entries are dropped. */
+  /** Parse `module=version,module=version`; malformed entries are dropped. */
   def parseMap(raw: String): Map[String, String] =
     raw
       .split(',')
@@ -42,7 +32,6 @@ object PcVersionOverride {
   private def read(prop: String, env: String): Option[String] =
     Option(System.getProperty(prop)).orElse(Option(System.getenv(env))).map(_.trim).filter(_.nonEmpty)
 
-  /** Read the override from system properties / env at startup. */
   def fromEnv: PcVersionOverride =
     PcVersionOverride(
       perModule = read("sls.pc.versions", "SLS_PC_VERSIONS").map(parseMap).getOrElse(Map.empty),

--- a/sls/src/org/scala/abusers/sls/pc/PcVersionOverride.scala
+++ b/sls/src/org/scala/abusers/sls/pc/PcVersionOverride.scala
@@ -1,0 +1,51 @@
+package org.scala.abusers.pc
+
+/** Debugging knob: override which `scala3-presentation-compiler_3` version the PC is loaded from, decoupled from the
+  * build target's own Scala version. Resolved once at startup from system properties (env vars as fallback), so it is
+  * toggled per launch with no recompile — same `-Dsls.*` convention as `sls.profiling`.
+  *
+  *   - `-Dsls.pc.version=<v>` (env `SLS_PC_VERSION`): global default applied to every module.
+  *   - `-Dsls.pc.versions=<module>=<v>,<module>=<v>` (env `SLS_PC_VERSIONS`): per-module map, keyed by build-target
+  *     display name; takes precedence over the global default.
+  *
+  * Resolution for a module is: per-module entry, else global default, else the target's own Scala version. Combined
+  * with coursier's `ivy2Local` default repository this makes a locally `publishLocal`-ed PC build directly usable.
+  */
+final case class PcVersionOverride(perModule: Map[String, String], global: Option[String]) {
+
+  /** Effective PC artifact version for `module`, falling back to `default` (the target's own Scala version). */
+  def resolve(module: String, default: ScalaVersion): ScalaVersion =
+    perModule.get(module).orElse(global).map(ScalaVersion(_)).getOrElse(default)
+
+  val isActive: Boolean = perModule.nonEmpty || global.isDefined
+}
+
+object PcVersionOverride {
+
+  val empty: PcVersionOverride = PcVersionOverride(Map.empty, None)
+
+  /** Parse a `module=version,module=version` list; malformed entries are dropped. */
+  def parseMap(raw: String): Map[String, String] =
+    raw
+      .split(',')
+      .iterator
+      .map(_.trim)
+      .filter(_.nonEmpty)
+      .flatMap { entry =>
+        entry.split("=", 2) match {
+          case Array(k, v) if k.trim.nonEmpty && v.trim.nonEmpty => Some(k.trim -> v.trim)
+          case _                                                 => None
+        }
+      }
+      .toMap
+
+  private def read(prop: String, env: String): Option[String] =
+    Option(System.getProperty(prop)).orElse(Option(System.getenv(env))).map(_.trim).filter(_.nonEmpty)
+
+  /** Read the override from system properties / env at startup. */
+  def fromEnv: PcVersionOverride =
+    PcVersionOverride(
+      perModule = read("sls.pc.versions", "SLS_PC_VERSIONS").map(parseMap).getOrElse(Map.empty),
+      global = read("sls.pc.version", "SLS_PC_VERSION"),
+    )
+}

--- a/sls/src/org/scala/abusers/sls/pc/PresentationCompilerProvider.scala
+++ b/sls/src/org/scala/abusers/sls/pc/PresentationCompilerProvider.scala
@@ -52,10 +52,7 @@ private class CachingPresentationCompilerProvider(
     IO.blocking {
       val fullClasspath    = compilerClasspath ++ projectClasspath
       val urlFullClasspath = fullClasspath.map(_.toFile.toURI.toURL)
-      // Isolate from the host's bundled scala3-compiler: load dotty.tools.* + stdlib from these jars, share only the
-      // sls<->PC bridge packages with the host. See PcParentClassLoader.
-      val parent = PcParentClassLoader(getClass.getClassLoader)
-      URLClassLoader(urlFullClasspath.toArray, parent)
+      URLClassLoader(urlFullClasspath.toArray, PcParentClassLoader(getClass.getClassLoader))
     }
 
   private def createPC(scalaVersion: ScalaVersion, projectClasspath: List[AbsolutePath], scalacOptions: List[String]) =
@@ -80,7 +77,7 @@ private class CachingPresentationCompilerProvider(
         )
       )
     }
-    // Inside the getOrUpdate thunk so it logs once per PC creation, not on every request.
+    // in the thunk so it logs once per PC creation, not per request
     compilers.getOrUpdate(info.buildTarget.id)(
       logOverride *> createPC(pcVersion, info.classpath, info.compilerOptions)
     )

--- a/sls/src/org/scala/abusers/sls/pc/PresentationCompilerProvider.scala
+++ b/sls/src/org/scala/abusers/sls/pc/PresentationCompilerProvider.scala
@@ -24,6 +24,7 @@ trait PresentationCompilerProvider {
 private class CachingPresentationCompilerProvider(
     serviceLoader: BlockingServiceLoader,
     compilers: SCache[IO, BuildTargetIdentifier, RawPresentationCompiler],
+    versionOverride: PcVersionOverride,
 ) extends PresentationCompilerProvider {
   private val cache = Cache.create() // .withLogger TODO No completions here
 
@@ -63,8 +64,15 @@ private class CachingPresentationCompilerProvider(
       )
     } yield pc.newInstance("pc-id-replace", projectClasspath.map(_.toNioPath).asJava, scalacOptions0.toList.asJava)
 
-  def get(info: ScalaBuildTargetInformation)(using SynchronizedState): IO[RawPresentationCompiler] =
-    compilers.getOrUpdate(info.buildTarget.id)(createPC(info.scalaVersion, info.classpath, info.compilerOptions))
+  def get(info: ScalaBuildTargetInformation)(using SynchronizedState): IO[RawPresentationCompiler] = {
+    val pcVersion = versionOverride.resolve(info.displayName, info.scalaVersion)
+    val logOverride = IO.whenA(pcVersion.value != info.scalaVersion.value) {
+      IO.consoleForIO.error(
+        s"PC version override for module '${info.displayName}': ${info.scalaVersion.value} -> ${pcVersion.value}"
+      )
+    }
+    logOverride *> compilers.getOrUpdate(info.buildTarget.id)(createPC(pcVersion, info.classpath, info.compilerOptions))
+  }
 }
 
 object PresentationCompilerProvider {
@@ -82,7 +90,7 @@ object PresentationCompilerProvider {
           ExpiringCache.Config(expireAfterRead = 5.minutes),
           None,
         )
-    } yield CachingPresentationCompilerProvider(serviceLoader, cache)
+    } yield CachingPresentationCompilerProvider(serviceLoader, cache, PcVersionOverride.fromEnv)
 }
 
 opaque type ScalaVersion = String

--- a/sls/src/org/scala/abusers/sls/pc/PresentationCompilerProvider.scala
+++ b/sls/src/org/scala/abusers/sls/pc/PresentationCompilerProvider.scala
@@ -10,6 +10,7 @@ import org.scala.abusers.sls.CoursierResolver
 import org.scala.abusers.sls.ScalaBuildTargetInformation
 import org.scala.abusers.sls.ScalaBuildTargetInformation.*
 import org.scala.abusers.sls.SynchronizedState
+import org.slf4j.LoggerFactory
 
 import java.net.URLClassLoader
 import scala.concurrent.duration.*
@@ -26,7 +27,8 @@ private class CachingPresentationCompilerProvider(
     compilers: SCache[IO, BuildTargetIdentifier, RawPresentationCompiler],
     versionOverride: PcVersionOverride,
 ) extends PresentationCompilerProvider {
-  private val cache = Cache.create() // .withLogger TODO No completions here
+  private val logger = LoggerFactory.getLogger(getClass)
+  private val cache  = Cache.create() // .withLogger TODO No completions here
 
   private def fetchPresentationCompilerJars(scalaVersion: ScalaVersion): IO[Seq[AbsolutePath]] = {
     val dep = Dependency.of(
@@ -50,7 +52,10 @@ private class CachingPresentationCompilerProvider(
     IO.blocking {
       val fullClasspath    = compilerClasspath ++ projectClasspath
       val urlFullClasspath = fullClasspath.map(_.toFile.toURI.toURL)
-      URLClassLoader(urlFullClasspath.toArray)
+      // Isolate from the host's bundled scala3-compiler: load dotty.tools.* + stdlib from these jars, share only the
+      // sls<->PC bridge packages with the host. See PcParentClassLoader.
+      val parent = PcParentClassLoader(getClass.getClassLoader)
+      URLClassLoader(urlFullClasspath.toArray, parent)
     }
 
   private def createPC(scalaVersion: ScalaVersion, projectClasspath: List[AbsolutePath], scalacOptions: List[String]) =
@@ -59,19 +64,26 @@ private class CachingPresentationCompilerProvider(
       classloader       <- freshPresentationCompilerClassloader(projectClasspath, compilerClasspath)
       pc <- serviceLoader.load(classOf[RawPresentationCompiler], PresentationCompilerProvider.classname, classloader)
       scalacOptions0 = scalacOptions ++ Seq("-Ywith-best-effort-tasty", "-Ybest-effort")
-      _ <- IO.consoleForIO.error(
-        s"Creating presentation compiler with classpath: ${projectClasspath.map(_.toNioPath.toString).mkString(", ")} and options: ${scalacOptions0.mkString(" ")}"
+      _ <- IO(
+        logger.info(
+          s"Creating presentation compiler with classpath: ${projectClasspath.map(_.toNioPath.toString).mkString(", ")} and options: ${scalacOptions0.mkString(" ")}"
+        )
       )
     } yield pc.newInstance("pc-id-replace", projectClasspath.map(_.toNioPath).asJava, scalacOptions0.toList.asJava)
 
   def get(info: ScalaBuildTargetInformation)(using SynchronizedState): IO[RawPresentationCompiler] = {
     val pcVersion = versionOverride.resolve(info.displayName, info.scalaVersion)
     val logOverride = IO.whenA(pcVersion.value != info.scalaVersion.value) {
-      IO.consoleForIO.error(
-        s"PC version override for module '${info.displayName}': ${info.scalaVersion.value} -> ${pcVersion.value}"
+      IO(
+        logger.info(
+          s"PC version override for module '${info.displayName}': ${info.scalaVersion.value} -> ${pcVersion.value}"
+        )
       )
     }
-    logOverride *> compilers.getOrUpdate(info.buildTarget.id)(createPC(pcVersion, info.classpath, info.compilerOptions))
+    // Inside the getOrUpdate thunk so it logs once per PC creation, not on every request.
+    compilers.getOrUpdate(info.buildTarget.id)(
+      logOverride *> createPC(pcVersion, info.classpath, info.compilerOptions)
+    )
   }
 }
 

--- a/sls/test/src/org/scala/abusers/sls/pc/PcVersionOverrideSpec.scala
+++ b/sls/test/src/org/scala/abusers/sls/pc/PcVersionOverrideSpec.scala
@@ -1,0 +1,18 @@
+package org.scala.abusers.pc
+
+import weaver.SimpleIOSuite
+
+object PcVersionOverrideSpec extends SimpleIOSuite {
+
+  pureTest("parseMap reads module=version entries and drops malformed ones") {
+    val parsed = PcVersionOverride.parseMap("sls=3.8.4-SNAPSHOT, zincCli=3.8.3 ,broken,=novalue,nokey=")
+    expect(parsed == Map("sls" -> "3.8.4-SNAPSHOT", "zincCli" -> "3.8.3"))
+  }
+
+  pureTest("per-module entry wins over global, global wins over default, default otherwise") {
+    val ov = PcVersionOverride(perModule = Map("sls" -> "9.9.9"), global = Some("8.8.8"))
+    expect(ov.resolve("sls", ScalaVersion("3.8.3")).value == "9.9.9") and
+      expect(ov.resolve("zincCli", ScalaVersion("3.8.3")).value == "8.8.8") and
+      expect(PcVersionOverride.empty.resolve("sls", ScalaVersion("3.8.3")).value == "3.8.3")
+  }
+}


### PR DESCRIPTION
## What

A launch-time knob to load the presentation compiler from a *different* `scala3-presentation-compiler_3` version than the build target's own Scala version — and the classloader/dependency work needed to actually make such a PC load. Useful for testing a locally-built dotty PC against a real project.

### The override (commit 1)
- **`PcVersionOverride`** — resolved once at startup from system properties (env fallback):
  - `-Dsls.pc.version=<v>` / `SLS_PC_VERSION` — global default for every module.
  - `-Dsls.pc.versions=<module>=<v>,…` / `SLS_PC_VERSIONS` — per-module map, keyed by build-target display name, taking precedence over the global.
  - Resolution per module: per-module entry → global default → the target's own Scala version (unchanged behaviour when nothing is set).
- `PresentationCompilerProvider.get` resolves the effective version per module and logs (slf4j) once per PC creation when an override is active.
- Coursier's default `ivy2Local` repo means a `publishLocal`-ed snapshot resolves directly.

### Making it actually load (commit 2)
The override alone wasn't enough — a PC built against a different Scala version than sls's bundled compiler failed to load. Three coupled fixes:
- **`PcParentClassLoader`** — the PC's `URLClassLoader` used the host app loader as parent, so `dotty.tools.*` (e.g. `InteractiveDriver`) leaked from sls's bundled `scala3-compiler` (via `scala3-tasty-inspector`) while `dotty.tools.pc.*` loaded from the override jars → `NoSuchMethodError`. The new parent has the bootstrap loader as parent and shares only the host↔PC bridge packages (`scala.meta.pc`, `org.eclipse.lsp4j`, `com.google.gson`), forcing `dotty.tools.*` and the stdlib to load from the PC's own jars.
- **`build.mill`** — bump `mtags-interfaces` 1.6.3 → 1.6.7 so the shared `scala.meta.pc` interface has the methods newer PCs call (e.g. `sourcePathMode`).
- **`ServerImpl`** — 1.6.7 pulls a newer lsp4j where `Diagnostic.getMessage` is `Either[String, MarkupContent]`; a chimney transformer unwraps it to the `String` that `lsp.Diagnostic.message` expects.

## Note for review
Commit 2 globally bumps the host's `mtags-interfaces` (and transitively lsp4j) to make a newer PC line work. That's an intended dependency move, but worth a sanity check that 1.6.7 is the right floor.

## Why module-keyed
A project has multiple modules; pinning the PC per module (with a global fallback) lets you isolate debugging to one target in a cross-built project. The key is the build-target display name, logged on PC creation so it's discoverable.

## Future work
The override is currently static (read at startup). The design supports making it runtime-updatable via an LSP endpoint (`workspace/didChangeConfiguration` or a custom command) with no restart — hold it in a `Ref`, update on the endpoint, call `invalidateCompilers()`. Not in this PR.

## Test
`PcVersionOverrideSpec` covers map parsing (incl. malformed entries) and the precedence chain. `./mill sls.test` is fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)